### PR TITLE
Print a warning if the pool allocator has allocated blocks when calling System::finish

### DIFF
--- a/src/System/System.h
+++ b/src/System/System.h
@@ -167,6 +167,9 @@ namespace uammd{
       log<DEBUG2>("[System] finish");
       CudaSafeCall(cudaDeviceSynchronize());
       CudaCheckError();
+      if(get_default_resource<device_temporary_memory_resource>()->has_allocated_blocks()){
+	log<System::WARNING>("[System] System::finish was called but UAMMD-controlled resources were found. This will probably result in a crash.");
+      }
       get_default_resource<device_temporary_memory_resource>()->free_all();
       this->printFarewell();
     }

--- a/src/misc/allocator.h
+++ b/src/misc/allocator.h
@@ -146,6 +146,10 @@ namespace uammd{
       return res->do_is_equal(other);
     }
 
+    bool has_allocated_blocks() const noexcept{
+      return allocated_blocks.size() > 0;
+    }
+
     void free_all(){
       for(auto &i: free_blocks) res->do_deallocate(static_cast<pointer>(i.second), i.first, 0);
       for(auto &i: allocated_blocks) res->do_deallocate(static_cast<pointer>(i.first), i.second, 0);


### PR DESCRIPTION
An snippet similar to the one presented in #14 will result in a crash with a cryptic message because it inadvertedly breaks the rule that "all UAMMD objects are invalidated after calling finish". This PR detects this particular usage and prints a (hopefully) less cryptic message.
cc @PabloIbannez 