### PR TITLE
Compute deltaRFD without using hydrodynamicRadius in DPStokesIntegrator

### DIFF
--- a/src/Integrator/BDHI/DoublyPeriodic/DPStokesSlab.cuh
+++ b/src/Integrator/BDHI/DoublyPeriodic/DPStokesSlab.cuh
@@ -276,7 +276,7 @@ else throw std::runtime_error("[DPStokesSlab] Can only average in direction X (0
 	System::log<System::MESSAGE>("[DPStokes] temperature: %g", par.temperature);
 	this->seed = pd->getSystem()->rng().next32();
 	this->seedRFD = pd->getSystem()->rng().next32();
-	this->deltaRFD = 1e-6*par.hydrodynamicRadius;
+	this->deltaRFD = 1e-6;
       }
 
       //Returns the thermal drift term: temperature*dt*(\partial_q \cdot M)


### PR DESCRIPTION
It is possible to initialize DPStokesIntegrator without setting the hydrodynamic radius. This causes deltaRFD to be zero and everything to turn NaN down the line