### PR TITLE
Remove copy of gridVels to a std::vector in FCM

### DIFF
--- a/src/Integrator/BDHI/FCM/FCM_impl.cuh
+++ b/src/Integrator/BDHI/FCM/FCM_impl.cuh
@@ -239,8 +239,6 @@ namespace uammd{
 	auto d_gridVels = (real3*)thrust::raw_pointer_cast(gridVels.data());
 	IBM<Kernel> ibm(kernel, grid, IBM_ns::LinearIndex3D(nx, n.y, n.z));
 	ibm.spread(pos, force_r3, d_gridVels, numberParticles, st);
-	std::vector<real3> hvels(gridVels.size());
-	thrust::copy(gridVels.begin(), gridVels.end(), hvels.begin());
 	CudaCheckError();
 	return gridVels;
       }


### PR DESCRIPTION
In FCM_impl.cuh, while spreading forces, there is an unnecessary operation where data is copied from a cached_vector to a std::vector (specifically gridVels). This std::vector does not seem to serve any functional purpose, and the copy operation is quite time-consuming.