### PR TITLE
Install headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10)
+project(uammd)
+# Install headers
+file(GLOB_RECURSE headers src/*)
+
+foreach(header ${headers})
+	get_filename_component(header_path ${header} PATH)
+	file(RELATIVE_PATH header_path_rel ${CMAKE_CURRENT_SOURCE_DIR}/src ${header_path})
+	install(FILES ${header} DESTINATION include/uammd/${header_path_rel})
+endforeach()
+
+# Install FindUAMMD.cmake
+install(FILES cmake/FindUAMMD.cmake DESTINATION share/cmake/Modules)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ mamba env create -f environment.yml
 
 **UAMMD does not need to be compiled separatedly (it is header only)**.  
 
+The top-level CMakeLists.txt file will install all UAMMD headers to `$CMAKE_INSTALL_PREFIX/include/uammd`. Additionally, a cmake module file (`FindUAMMD.cmake` will be installed at `$CMAKE_INSTALL_PREFIX/share/cmake/Modules`). To install the headers, go to the root of this repo and run:
+
+```shell
+$ mkdir build && cd build
+$ cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX .. # If you wish to install the headers to the conda environment
+$ make install
+```
+
+Now other CMake scripts can find the UAMMD headers with:
+
+```cmake
+find_package(UAMMD REQUIRED)
+include_directories(${UAMMD_INCLUDE_DIR})
+```
+
 Some special flags might be needed to compile codes including with certain UAMMD headers, see [Compiling UAMMD](https://uammd.readthedocs.io/en/latest/Compiling-UAMMD.html).  
 Here you have a short example of how a typical UAMMD code looks like, encoding a simple Brownian dynamics simulation of non interacting particles.:  
 

--- a/cmake/FindUAMMD.cmake
+++ b/cmake/FindUAMMD.cmake
@@ -1,0 +1,26 @@
+# Looks for the uammd include folder in the system and sets the UAMMD_INCLUDE_DIR variable.
+# Usage:
+# find_package(UAMMD REQUIRED)
+# include_directories(${UAMMD_INCLUDE_DIR})
+# The include folder can be in the following locations:
+# 1. In the system include folder: /usr/include/uammd
+# 2. In the user's home folder: ~/uammd/include/uammd
+# 3. In the conda environment: $ENV{CONDA_PREFIX}/include/uammd
+
+# First, look for the include folder in the system.
+find_path(UAMMD_INCLUDE_DIR uammd.cuh HINTS /usr/include/uammd)
+
+# If the include folder is not found, look for it in the user's home folder.
+if(NOT UAMMD_INCLUDE_DIR)
+  find_path(UAMMD_INCLUDE_DIR uammd.cuh HINTS $ENV{HOME}/uammd/include/uammd)
+endif()
+
+# If the include folder is not found, look for it in the conda environment.
+if(NOT UAMMD_INCLUDE_DIR)
+  find_path(UAMMD_INCLUDE_DIR uammd.cuh HINTS $ENV{CONDA_PREFIX}/include/uammd)
+endif()
+
+# Add also the folder UAMMD_INCLUDE_DIR/third_party to the include directories.
+if(UAMMD_INCLUDE_DIR)
+  set(UAMMD_INCLUDE_DIR ${UAMMD_INCLUDE_DIR} ${UAMMD_INCLUDE_DIR}/third_party)
+endif()

--- a/cmake/FindUAMMD.cmake
+++ b/cmake/FindUAMMD.cmake
@@ -1,26 +1,26 @@
-# Looks for the uammd include folder in the system and sets the UAMMD_INCLUDE_DIR variable.
+# Looks for the uammd include folder in the system and sets the UAMMD_INCLUDE_DIRS variable.
 # Usage:
 # find_package(UAMMD REQUIRED)
-# include_directories(${UAMMD_INCLUDE_DIR})
+# include_directories(${UAMMD_INCLUDE_DIRS})
 # The include folder can be in the following locations:
 # 1. In the system include folder: /usr/include/uammd
 # 2. In the user's home folder: ~/uammd/include/uammd
 # 3. In the conda environment: $ENV{CONDA_PREFIX}/include/uammd
 
 # First, look for the include folder in the system.
-find_path(UAMMD_INCLUDE_DIR uammd.cuh HINTS /usr/include/uammd)
+find_path(UAMMD_INCLUDE_DIRS uammd.cuh HINTS /usr/include/uammd)
 
 # If the include folder is not found, look for it in the user's home folder.
-if(NOT UAMMD_INCLUDE_DIR)
-  find_path(UAMMD_INCLUDE_DIR uammd.cuh HINTS $ENV{HOME}/uammd/include/uammd)
+if(NOT UAMMD_INCLUDE_DIRS)
+  find_path(UAMMD_INCLUDE_DIRS uammd.cuh HINTS $ENV{HOME}/uammd/include/uammd)
 endif()
 
 # If the include folder is not found, look for it in the conda environment.
-if(NOT UAMMD_INCLUDE_DIR)
-  find_path(UAMMD_INCLUDE_DIR uammd.cuh HINTS $ENV{CONDA_PREFIX}/include/uammd)
+if(NOT UAMMD_INCLUDE_DIRS)
+  find_path(UAMMD_INCLUDE_DIRS uammd.cuh HINTS $ENV{CONDA_PREFIX}/include/uammd)
 endif()
 
-# Add also the folder UAMMD_INCLUDE_DIR/third_party to the include directories.
-if(UAMMD_INCLUDE_DIR)
-  set(UAMMD_INCLUDE_DIR ${UAMMD_INCLUDE_DIR} ${UAMMD_INCLUDE_DIR}/third_party)
+# Add also the folder UAMMD_INCLUDE_DIRS/third_party to the include directories.
+if(UAMMD_INCLUDE_DIRS)
+  set(UAMMD_INCLUDE_DIRS ${UAMMD_INCLUDE_DIRS} ${UAMMD_INCLUDE_DIRS}/third_party)
 endif()


### PR DESCRIPTION
I added a top-level CMake file that installs every uammd header to `$CMAKE_INSTALL_PREFIX/include/uammd`.

I also added a FindUAMMD.cmake module that looks for these, so that it is possible to call:

```cmake
find_package(UAMMD REQUIRED)
include_directories(${UAMMD_INCLUDE_DIRS})
```
regardless of where UAMMD is installed.
FindUAMMD.cmake is installed to `$CMAKE_INSTALL_PREFIX/share/cmake/Modules`
