### PR TITLE
Fix race condition in fillGhostCells in ICM_Compressible when walls are present

### DIFF
--- a/src/Integrator/Hydro/ICM_Compressible/FluidSolver.cuh
+++ b/src/Integrator/Hydro/ICM_Compressible/FluidSolver.cuh
@@ -130,7 +130,7 @@ namespace uammd{
       // 3- a=1/3, b=2/3 and c=n+1
       template<int subStep, class EquationOfState>
       __global__ void rungeKuttaSubStepD(FluidTimePack fluid, DataXYZPtr fluidForcingAtHalfStep,
-					 real2* fluidStochasticTensor,
+					 const real2* fluidStochasticTensor,
 					 FluidParameters par, EquationOfState densityToPressure,
 					 int step,
 					 Grid grid,

--- a/src/Integrator/Hydro/ICM_Compressible/utils.cuh
+++ b/src/Integrator/Hydro/ICM_Compressible/utils.cuh
@@ -43,6 +43,7 @@ namespace uammd{
 
 	DataXYZ(int size){
 	  resize(size);
+	  fillWithZero();
 	}
 
 	void resize(int newSize){
@@ -108,19 +109,18 @@ namespace uammd{
 	FluidPointers(){}
 	template<class RealContainer>
 	FluidPointers(const RealContainer &dens, const DataXYZ &vel, const DataXYZ &momentum):
-	  density(thrust::raw_pointer_cast(dens.data())),
-	  velocityX(vel.x()), velocityY(vel.y()), velocityZ(vel.z()),
-	  momentumX(momentum.x()), momentumY(momentum.y()), momentumZ(momentum.z()){}
+	  density(const_cast<real*>(thrust::raw_pointer_cast(dens.data()))),
+	  velocityX(const_cast<real*>(vel.x())), velocityY(const_cast<real*>(vel.y())), velocityZ(const_cast<real*>(vel.z())),
+	  momentumX(const_cast<real*>(momentum.x())), momentumY(const_cast<real*>(momentum.y())), momentumZ(const_cast<real*>(momentum.z())){}
 	real* density;
 	DataXYZ::Iterator velocityX, velocityY, velocityZ;
 	DataXYZ::Iterator momentumX, momentumY, momentumZ;
       };
 
       struct FluidData{
-	FluidData(int3 n):
-	  momentum(n.x*n.y*n.z),
-	  velocity(n.x*n.y*n.z),
-	  density(n.x*n.y*n.z){}
+	FluidData(int3 n){
+	  resize(n);
+	}
 
 	FluidData(): FluidData({0,0,0}){}
 

--- a/src/Integrator/Hydro/ICM_Compressible/utils.cuh
+++ b/src/Integrator/Hydro/ICM_Compressible/utils.cuh
@@ -43,7 +43,6 @@ namespace uammd{
 
 	DataXYZ(int size){
 	  resize(size);
-	  fillWithZero();
 	}
 
 	void resize(int newSize){


### PR DESCRIPTION
In the presence of walls in the Z direction. The ICM Compressible module will constantly fill the ghost cells with periodic information.
When walls are present in the Z direction, the wall object is asked to fill the ghost cells for the first and last layers AFTER the ghost cells for the volume have been periodified.

There was, however, no synchronization between ghostifying the volume and applying the wall conditions. This only matters in the 8 corners of the domain, were the wall requires all other ghost cells to have been filled already.


This PR fixes it by synchronizing between the two steps. 