### PR TITLE
Remove non ascii characters

### DIFF
--- a/examples/generic_md/customizations.cuh
+++ b/examples/generic_md/customizations.cuh
@@ -319,7 +319,7 @@ struct HarmonicBond {
     real3 r12 = pos[1] - pos[0];
     real r2 = dot(r12, r12);
     const real invr = rsqrt(r2);
-    const real f = -bi.k * (real(1.0) - bi.r0 * invr); // F = -k·(r-r0)·rvec/r
+    const real f = -bi.k * (real(1.0) - bi.r0 * invr); // F = -k*(r-r0)*rvec/r
     ComputeType ct;
     ct.force = f * r12;
     ct.energy = comp.energy ? (real(0.5) * bi.k * sq(real(1.0) / invr - bi.r0))
@@ -393,7 +393,7 @@ struct Angular {
     // //sijk cant be zero to avoid division by zero
     // if(sijk<std::numeric_limits<real>::min()) sijk =
     // std::numeric_limits<real>::min(); ampli = -kspring * (acos(cijk) -
-    // ang0)/sijk; //The force amplitude -k·(theta-theta_0)
+    // ang0)/sijk; //The force amplitude -k*(theta-theta_0)
     // ampli = -kspring*(-sijk*cos(ang0)+cijk*sin(ang0))+ang0;
     // //k(1-cos(ang-ang0))
     if (ang0 == real(0.0)) {

--- a/examples/generic_md/generic_simulation.cu
+++ b/examples/generic_md/generic_simulation.cu
@@ -308,7 +308,7 @@ auto createIntegratorSPH(UAMMD sim) {
   SPH::Parameters params;
   params.box = Box(sim.par.L);
   // Pressure for a given particle "i" in SPH will be computed as
-  // gasStiffness·(density_i - restDensity) Where density is computed as a
+  // gasStiffness*(density_i - restDensity) Where density is computed as a
   // function of the masses of the surroinding particles Particle mass starts as
   // 1, but you can change this in customizations.cuh
   params.support = sim.par.support_sph; // Cut off distance for the SPH kernel
@@ -639,7 +639,7 @@ void writeDefaultDatamain(std::string datamain) {
   out << "#cutOff_dpd 1" << std::endl;
   out << "#These parameters will be used by SPH only" << std::endl;
   out << "#Pressure for a given particle \"i\" in SPH will be computed as "
-         "gasStiffness·(density_i - restDensity)"
+         "gasStiffness*(density_i - restDensity)"
       << std::endl;
   out << "#Where density is computed as a function of the masses of the "
          "surroinding particles"

--- a/examples/integration_schemes/integrators.cu
+++ b/examples/integration_schemes/integrators.cu
@@ -120,7 +120,7 @@ std::shared_ptr<Integrator> createIntegratorSPH(UAMMD sim) {
   real3 L = make_real3(32, 32, 32);
   params.box = Box(L);
   // Pressure for a given particle "i" in SPH will be computed as
-  // gasStiffness·(density_i - restDensity) Where density is computed as a
+  // gasStiffness*(density_i - restDensity) Where density is computed as a
   // function of the masses of the surroinding particles Particle mass starts as
   // 1, but you can change this in customizations.cuh
   params.support = 2.4;   // Cut off distance for the SPH kernel

--- a/examples/interaction_modules/Bonds.cu
+++ b/examples/interaction_modules/Bonds.cu
@@ -90,7 +90,7 @@ struct HarmonicBond {
     real3 r12 = pos[1] - pos[0];
     real r2 = dot(r12, r12);
     const real invr = rsqrt(r2);
-    const real f = -bi.k * (real(1.0) - bi.r0 * invr); // F = -k·(r-r0)·rvec/r
+    const real f = -bi.k * (real(1.0) - bi.r0 * invr); // F = -k*(r-r0)*rvec/r
     ComputeType ct;
     ct.force = f * r12;
     ct.energy = comp.energy ? (real(0.5) * bi.k * sq(real(1.0) / invr - bi.r0))
@@ -164,7 +164,7 @@ struct Angular {
     // //sijk cant be zero to avoid division by zero
     // if(sijk<std::numeric_limits<real>::min()) sijk =
     // std::numeric_limits<real>::min(); ampli = -kspring * (acos(cijk) -
-    // ang0)/sijk; //The force amplitude -k·(theta-theta_0)
+    // ang0)/sijk; //The force amplitude -k*(theta-theta_0)
     // ampli = -kspring*(-sijk*cos(ang0)+cijk*sin(ang0))+ang0;
     // //k(1-cos(ang-ang0))
     if (ang0 == real(0.0)) {

--- a/examples/uammd_as_a_library/python_wrapper.cu
+++ b/examples/uammd_as_a_library/python_wrapper.cu
@@ -185,7 +185,7 @@ PYBIND11_MODULE(uammd, m) {
       . // You can also set default values for the arguments
       def_readwrite("sigma", &Parameters::sigma, "LJ sigma")
       . // You can also allow each member to be modifiable and add a doc string
-        // to it
+      // to it
       def_readwrite("epsilon", &Parameters::epsilon, "LJ epsilon")
       .def_readwrite("cutOff", &Parameters::cutOff, "LJ cutOff")
       .def_readwrite("box", &Parameters::box, "Domain")

--- a/src/Integrator/BDHI/BDHI.cuh
+++ b/src/Integrator/BDHI/BDHI.cuh
@@ -53,7 +53,7 @@ struct RotnePragerYamakawa {
     return c12 * (M0 * invrh);
   }
 
-  // Taken from "Rotne–Prager–Yamakawa approximation for different-sized
+  // Taken from "Rotne-Prager-Yamakawa approximation for different-sized
   // particles in application to macromolecular bead models", P.J. Zik et.al.
   // 2014
   inline __host__ __device__ real2 RPY_differentSizes(real r, real ai,

--- a/src/Integrator/BDHI/BDHI_Cholesky.cuh
+++ b/src/Integrator/BDHI/BDHI_Cholesky.cuh
@@ -2,14 +2,14 @@
 
   See BDHI_EulerMaruyama.cuh to see how it is used
 
-  Any BDHI method needs to do only three things: compute M·F, sqrt(M)·dW,
+  Any BDHI method needs to do only three things: compute M*F, sqrt(M)*dW,
   div(M).
 
 
   BDHI::Cholesky stores the full Mobility Matrix and computes the stochastic
   term via cholesky decomposition.
 
-  sqrt(M)dW = B·dW -> D = B·B^T
+  sqrt(M)dW = B*dW -> D = B*B^T
 
   It uses cuBLAS for Mv products and cuSOLVER for Cholesky decomposition
 

--- a/src/Integrator/BDHI/BDHI_EulerMaruyama.cu
+++ b/src/Integrator/BDHI/BDHI_EulerMaruyama.cu
@@ -2,7 +2,7 @@
   Integrator derived class implementation
 
   Solves the following stochastich differential equation:
-  X[t+dt] = dt(K·X[t]+M·F[t]) + sqrt(2*kb*T*dt)·B·dW
+  X[t+dt] = dt(K*X[t]+M*F[t]) + sqrt(2*kb*T*dt)*B*dW
   Being:
   X - Positions
   M - Mobility matrix -> M = D/kT
@@ -15,13 +15,13 @@
   The module offers several ways to compute and solve the different terms.
 
   BDHI::Cholesky:
-  -Computing M·F and B·dW  explicitly storing M and performing a Cholesky
+  -Computing M*F and B*dW  explicitly storing M and performing a Cholesky
   decomposition on M.
 
   BDHI::Lanczos:
   -A Lanczos iterative method to reduce M to a smaller Krylov subspace and
-  performing the operation B·dW there, the product M·F is performed in a
-  matrix-free way, recomputing M every time M·v is needed.
+  performing the operation B*dW there, the product M*F is performed in a
+  matrix-free way, recomputing M every time M*v is needed.
 
   BDHI::PSE:
   -The Positively Split Edwald Method, which takes the computation to fourier
@@ -77,7 +77,7 @@ template <class Method> EulerMaruyama<Method>::~EulerMaruyama() {
 }
 
 namespace EulerMaruyama_ns {
-// dR = dt(KR+MF) + sqrt(2*T*dt)·BdW
+// dR = dt(KR+MF) + sqrt(2*T*dt)*BdW
 template <class IndexIterator>
 __global__ void
 integrateGPUD(real4 *__restrict__ pos, IndexIterator indexIterator,
@@ -125,7 +125,7 @@ template <class Method> void EulerMaruyama<Method>::resetForces() {
 template <class Method> void EulerMaruyama<Method>::forwardTime() {
   System::log<System::DEBUG1>(
       "[BDHI::EulerMaruyama] Performing integration step %d", steps);
-  // dR = dt(KR+MF) + sqrt(2*T*dt)·BdW
+  // dR = dt(KR+MF) + sqrt(2*T*dt)*BdW
   steps++;
   for (auto updatable : updatables)
     updatable->updateSimulationTime(steps * par.dt);

--- a/src/Integrator/BDHI/BDHI_EulerMaruyama.cuh
+++ b/src/Integrator/BDHI/BDHI_EulerMaruyama.cuh
@@ -2,7 +2,7 @@
 derived class implementation
 
   Solves the following stochastic differential equation:
-     X[t+dt] = dt(K·X[t]+M·F[t]) + sqrt(2*kb*T*dt)·B·dW + T·divM·dt(in 2D)
+     X[t+dt] = dt(K*X[t]+M*F[t]) + sqrt(2*kb*T*dt)*B*dW + T*divM*dt(in 2D)
    Being:
      X - Positions
      M - Mobility matrix
@@ -16,13 +16,13 @@ B=sqrt(M) div(M) - Divergence of the mobility matrix, only non-zero in 2D
   The module offers several ways to compute and solve the different terms.
 
   BDHI::Cholesky:
-  -Computing M·F and B·dW  explicitly storing M and performing a Cholesky
+  -Computing M*F and B*dW  explicitly storing M and performing a Cholesky
 decomposition on M.
 
   BDHI::Lanczos:
   -A Lanczos iterative method to reduce M to a smaller Krylov subspace and
-performing the operation B·dW there, the product M·F is performed in a
-matrix-free way, recomputing M every time M·v is needed.
+performing the operation B*dW there, the product M*F is performed in a
+matrix-free way, recomputing M every time M*v is needed.
 
   BDHI::PSE:
   -The Positively Split Edwald Method, which takes the computation to fourier
@@ -82,8 +82,8 @@ public:
   real getSelfMobility() { return bdhi->getSelfMobility(); }
 
 private:
-  thrust::device_vector<real3> MF;  /*Result of M·F*/
-  thrust::device_vector<real3> BdW; /*Result of B·dW*/
+  thrust::device_vector<real3> MF;  /*Result of M*F*/
+  thrust::device_vector<real3> BdW; /*Result of B*dW*/
   thrust::device_vector<real3> K;   /*Shear 3x3 matrix*/
 
   cudaStream_t stream, stream2;

--- a/src/Integrator/BDHI/BDHI_FCM.cu
+++ b/src/Integrator/BDHI/BDHI_FCM.cu
@@ -58,7 +58,7 @@ void FCMIntegrator::computeCurrentForces() {
 
 namespace FCM_ns {
 /*
-  dR = dt(KR+MF) + sqrt(2*T*dt)·BdW +T·divM·dt -> divergence is commented out
+  dR = dt(KR+MF) + sqrt(2*T*dt)*BdW +T*divM*dt -> divergence is commented out
   for the moment
 */
 /*With all the terms computed, update the positions*/

--- a/src/Integrator/BDHI/BDHI_FCM.cuh
+++ b/src/Integrator/BDHI/BDHI_FCM.cuh
@@ -111,20 +111,23 @@ public:
 
   void setup_step(cudaStream_t st = 0) {}
 
-/**
- * @brief Computes \f{M \cdot F\f} and \f{B \cdot dW\f} in Fourier space.
- *
- * \f[
- * \sigma = dx \cdot dy \cdot dz \quad (\text{cell volume as } h^3 \text{ in [1]})
- * \f]
- *
- * The computation follows:
- * \f[
- * M_w \cdot F + \sqrt{M_w} \cdot dW_w = \sigma \cdot \text{St} \cdot \text{FFTi} \cdot B \cdot \text{FFTf} \cdot S \cdot F + 
- * \sqrt{\sigma} \cdot \text{St} \cdot \text{FFTi} \cdot \sqrt{B} \cdot dW_w = 
- * \sigma \cdot \text{St} \cdot \text{FFTi} \left( B \cdot \text{FFTf} \cdot S \cdot F + \frac{1}{\sqrt{\sigma}} \cdot \sqrt{B} \cdot dW_w \right)
- * \f]
- */
+  /**
+   * @brief Computes \f{M \cdot F\f} and \f{B \cdot dW\f} in Fourier space.
+   *
+   * \f[
+   * \sigma = dx \cdot dy \cdot dz \quad (\text{cell volume as } h^3 \text{ in
+   * [1]})
+   * \f]
+   *
+   * The computation follows:
+   * \f[
+   * M_w \cdot F + \sqrt{M_w} \cdot dW_w = \sigma \cdot \text{St} \cdot
+   * \text{FFTi} \cdot B \cdot \text{FFTf} \cdot S \cdot F +
+   * \sqrt{\sigma} \cdot \text{St} \cdot \text{FFTi} \cdot \sqrt{B} \cdot dW_w =
+   * \sigma \cdot \text{St} \cdot \text{FFTi} \left( B \cdot \text{FFTf} \cdot S
+   * \cdot F + \frac{1}{\sqrt{\sigma}} \cdot \sqrt{B} \cdot dW_w \right)
+   * \f]
+   */
   void computeMF(real3 *MF, cudaStream_t st = 0) {
     System::log<System::DEBUG1>("[BDHI::FCM] Computing MF....");
     auto pd = pg->getParticleData();

--- a/src/Integrator/BDHI/BDHI_FCM.cuh
+++ b/src/Integrator/BDHI/BDHI_FCM.cuh
@@ -111,11 +111,20 @@ public:
 
   void setup_step(cudaStream_t st = 0) {}
 
-  /*Compute M·F and B·dW in Fourier space
-  σ = dx*dy*dz; h^3 in [1]
-  Mw·F + sqrt(Mw)·dWw = σ·St·FFTi·B·FFTf·S·F+ √σ·St·FFTi·√B·dWw =
-  = σ·St·FFTi( B·FFTf·S·F + 1/√σ·√B·dWw)
-*/
+/**
+ * @brief Computes \f{M \cdot F\f} and \f{B \cdot dW\f} in Fourier space.
+ *
+ * \f[
+ * \sigma = dx \cdot dy \cdot dz \quad (\text{cell volume as } h^3 \text{ in [1]})
+ * \f]
+ *
+ * The computation follows:
+ * \f[
+ * M_w \cdot F + \sqrt{M_w} \cdot dW_w = \sigma \cdot \text{St} \cdot \text{FFTi} \cdot B \cdot \text{FFTf} \cdot S \cdot F + 
+ * \sqrt{\sigma} \cdot \text{St} \cdot \text{FFTi} \cdot \sqrt{B} \cdot dW_w = 
+ * \sigma \cdot \text{St} \cdot \text{FFTi} \left( B \cdot \text{FFTf} \cdot S \cdot F + \frac{1}{\sqrt{\sigma}} \cdot \sqrt{B} \cdot dW_w \right)
+ * \f]
+ */
   void computeMF(real3 *MF, cudaStream_t st = 0) {
     System::log<System::DEBUG1>("[BDHI::FCM] Computing MF....");
     auto pd = pg->getParticleData();

--- a/src/Integrator/BDHI/BDHI_Lanczos.cuh
+++ b/src/Integrator/BDHI/BDHI_Lanczos.cuh
@@ -4,7 +4,7 @@ BDHI::EulerMaruyama
   Computes the mobility matrix on the fly when needed, so it is a mtrix free
 method.
 
-  M·F is computed as an NBody interaction (a dense Matrix vector product).
+  M*F is computed as an NBody interaction (a dense Matrix vector product).
 
   BdW is computed using the Lanczos algorithm [1].
 

--- a/src/Integrator/BDHI/BDHI_PSE.cuh
+++ b/src/Integrator/BDHI/BDHI_PSE.cuh
@@ -43,11 +43,11 @@ scaling factor in wave space to transform forces to velocities, see eq.9 in [1].
 
   sqrt(Mw)*dWw: The far range stochastic contribution is computed in fourier
 space along M*F as: Mw*F + sqrt(Mw)*dWw = sigma*St*FFTi*B*FFTf*S*F+
-sqrt(sigma)*St*FFTi*sqrt(B)*dWw = sigma*St*FFTi( B*FFTf*S*F + 1/sqrt(sigma)*sqrt(B)*dWw) Only one St*FFTi is
-needed, the stochastic term is added as a velocity in fourier space. dWw is a
-gaussian random vector of complex numbers, special care must be taken to ensure
-the correct conjugacy properties needed for the FFT. See
-pse_ns::fourierBrownianNoise
+sqrt(sigma)*St*FFTi*sqrt(B)*dWw = sigma*St*FFTi( B*FFTf*S*F +
+1/sqrt(sigma)*sqrt(B)*dWw) Only one St*FFTi is needed, the stochastic term is
+added as a velocity in fourier space. dWw is a gaussian random vector of complex
+numbers, special care must be taken to ensure the correct conjugacy properties
+needed for the FFT. See pse_ns::fourierBrownianNoise
 
 Therefore, in the case of Mdot_far, for computing M*F, Bw*dWw is also summed.
 

--- a/src/Integrator/BDHI/FCM/utils.cuh
+++ b/src/Integrator/BDHI/FCM/utils.cuh
@@ -50,24 +50,46 @@ __device__ real3 getGradientFourier(int3 ik, int3 nk, real3 L) {
   return dk;
 }
 
-/*Apply the projection operator to a wave number with a certain real3 factor.
-  res = (I-\hat{k}^\hat{k})·factor
-  k2 is the laplacian operator in Fourier space, just the wave vector squared.
-  dk is the gradient operator in Fourier space, it is equal to the wave vector
-  but with the unpaired modes set to zero fr is the factor to project
-*/
+/**
+ * @brief Applies the projection operator to a wave number with a given real3
+ * factor.
+ *
+ * Computes the projection:
+ * \f[
+ * \mathbf{res} = \left( \mathbf{I} - \hat{\mathbf{k}}^\hat{\mathbf{k}}
+ * \right) \cdot \mathbf{fr}
+ * \f]
+ *
+ * @param k2 The laplacian operator in Fourier space, which is just the wave
+ * vector squared.
+ * @param dk The gradient operator in Fourier space. It is equal to the wave
+ * vector but with the unpaired modes set to zero.
+ * @param fr The vector to be projected.
+ * @return The projected vector \f$\mathbf{res}\f$.
+ */
 __device__ real3 projectFourier(real k2, real3 dk, real3 fr) {
   const real invk2 = real(1.0) / k2;
   real3 vr = fr - dk * dot(fr, dk * invk2);
   return vr;
 }
 
-/*Apply the projection operator to a wave number with a certain complex3 factor.
-  res = (I-\hat{k}^\hat{k})·factor
-  k2 is the laplacian operator in Fourier space, just the wave vector squared.
-  dk is the gradient operator in Fourier space, it is equal to the wave vector
-  but with the unpaired modes set to zero fr is the factor to project
-*/
+/**
+ * @brief Applies the projection operator to a wave number with a given complex3
+ * factor.
+ *
+ * Computes the projection:
+ * \f[
+ * \mathbf{res} = \left( \mathbf{I} - \hat{\mathbf{k}}^\hat{\mathbf{k}} \right)
+ * \cdot \mathbf{fr}
+ * \f]
+ *
+ * @param k2 The Laplacian operator in Fourier space, which is just the wave
+ * vector squared.
+ * @param dk The gradient operator in Fourier space. It is equal to the wave
+ * vector but with the unpaired modes set to zero.
+ * @param fr The complex-valued vector to be projected.
+ * @return The projected complex vector \f$\mathbf{res}\f$.
+ */
 __device__ complex3 projectFourier(real k2, real3 dk, complex3 factor) {
   real3 re =
       projectFourier(k2, dk, make_real3(factor.x.x, factor.y.x, factor.z.x));
@@ -77,9 +99,19 @@ __device__ complex3 projectFourier(real k2, real3 dk, complex3 factor) {
   return res;
 }
 
-/*Compute gaussian complex noise dW, std = prefactor -> ||z||^2 =
- * <x^2>/sqrt(2)+<y^2>/sqrt(2) = prefactor*/
-/*A complex random number for each direction*/
+/**
+ * @brief Computes Gaussian complex noise \f$dW\f$ with a given standard
+ * deviation.
+ *
+ * The complex noise is generated such that:
+ * \f[
+ * \| z \|^2 = \frac{\langle x^2 \rangle}{\sqrt{2}} + \frac{\langle y^2
+ * \rangle}{\sqrt{2}} = \text{prefactor}
+ * \f]
+ *
+ * @param prefactor The target variance magnitude for the noise.
+ * @return A complex-valued noise vector \f$dW\f$ with the specified statistics.
+ */
 __device__ complex3 generateNoise(
     real prefactor, uint id, uint seed1,
     uint seed2) { // Uncomment to use uniform numbers instead of gaussian

--- a/src/Integrator/BDHI/FIB/FIB.cuh
+++ b/src/Integrator/BDHI/FIB/FIB.cuh
@@ -19,7 +19,7 @@ hydrodynamic radius given here cannot be enforced exactly, rather the most
 approximate one will be computed by selecting an appropiate cellDimension (which
 will be an FFT wise number). par.hydrodynamicRadius = 1.0;
 //Instead of the hydrodynamic radius the cell dimensions can be provided
-directly. Giving rh~0.91·L/cellDim
+directly. Giving rh~0.91*L/cellDim
 //par.cells=make_int3(64,64,64); //cells.z == 1 means 2D
 //In any case a message will be issued with the used hydrodynamic radius.
 par.dt = 0.01;
@@ -57,10 +57,10 @@ to solve the velocity without computing or storing the pressure and can be
 written as:
   \mathcal{L}^-1 = -L^{-1}P
   Where L is the Laplacian operator and P aa projector onto the divergence-free
-space. P = I-L^{-1}·G -> \hat{P} = I-k·k^T/|k|^2 with PBC, G is gradient, \hat
+space. P = I-L^{-1}*G -> \hat{P} = I-k*k^T/|k|^2 with PBC, G is gradient, \hat
 represents Fourier space
 
-So \hat{\mathcal{L}^-1} =  1/|k|^2 (I - k·k^T/|k|^2)
+So \hat{\mathcal{L}^-1} =  1/|k|^2 (I - k*k^T/|k|^2)
 
 The different quantities are stored in a staggered grid, see [2].
 Vectors (velocity) is stored at cell faces, scalars at cell centers and tensors
@@ -68,7 +68,7 @@ at cell nodes (noise).
 
 The fluid forcing can be written as:
 
-\vec{g} = S^n·F^n + sqrt(2·\eta·kT/(dt·dV))·\hat{D}\bf{W}^{n,1} + kT/\delta [
+\vec{g} = S^n*F^n + sqrt(2*\eta*kT/(dt*dV))*\hat{D}\bf{W}^{n,1} + kT/\delta [
 S(q^n + \delta/2\hat{\bf{W}}^n) - S(q^n - \delta/2\hat{\bf{W}}^n)]\hat{\bf{W}}^n
 = particle forces + random advection + thermal drift Where S: Spreading
 operator.
@@ -76,19 +76,19 @@ operator.
 \bf{W}: Collection of independent Wienner processes.
 F: Forces acting on particles
 
-v_particles = J·v_fluid
+v_particles = J*v_fluid
 
-J: Interpolation operator J^T = dV·S
+J: Interpolation operator J^T = dV*S
 
 The particles are updated following the mid point (predictor-corrector) schemes
 developed in [1]. See midPointStep and improvedMidPointStep for more info.
-Euler: x^{t+dt} = x^t + v_particles·dt
+Euler: x^{t+dt} = x^t + v_particles*dt
 
 
 About J and S:
 
 S_cellj = sum_i=0^N{\delta(ri-r_cellj)} ->particles to fluid
-J_i = dV·sum_j=0^ncells{\delta(ri-r_cellj)}->fluid to particles
+J_i = dV*sum_j=0^ncells{\delta(ri-r_cellj)}->fluid to particles
 
 Where \delta is an spreading kernel (smeared delta).
 The default kernel used is the 3-point Peskin kernel, see IBM_kernels.cuh.

--- a/src/Integrator/BDHI/PSE/FarField.cuh
+++ b/src/Integrator/BDHI/PSE/FarField.cuh
@@ -42,10 +42,14 @@ public:
 
 namespace detail {
 using cufftComplex3 = cufftComplex3_t<real>;
-/*Apply the projection operator to a wave number with a certain complex factor.
-  res = (I-k^k)·factor
-  See i.e eq. 16 in [1].
-*/
+/**
+ * Apply the projection operator to a wave number with a given complex factor.
+ *
+ * Computes:
+ *   res = (I - k * k) * factor
+ *
+ * See, e.g., equation 16 in [1].
+ */
 __device__ cufftComplex3 projectFourier(real3 k, cufftComplex3 factor) {
   const real invk2 = real(1.0) / dot(k, k);
   cufftComplex3 res;
@@ -68,10 +72,16 @@ __device__ cufftComplex3 projectFourier(real3 k, cufftComplex3 factor) {
   return res;
 }
 
-/* Precomputes the fourier scaling factor B (see eq. 9 and 20.5 in [1]),
-   Returns B(||k||^2, xi, eta) = 1/(vis·Vol) ·
-   sinc(k·rh)^2/k^2·Hashimoto(k,xi,eta)
-*/
+/**
+ * Precomputes the Fourier-space scaling factor B.
+ *
+ * See equations 9 and 20.5 in [1].
+ *
+ * Returns:
+ *   B(||k||^2, xi, eta) = (1 / (viscosity * Vol)) *
+ *                         (sinc(k * rh))^2 / |k|^2 *
+ *                         Hashimoto(k, xi, eta)
+ */
 __device__ real greensFunction(real3 waveVector, real shearStrain,
                                real rh, // Hydrodynamic radius
                                real viscosity,
@@ -108,13 +118,19 @@ __device__ real greensFunction(real3 waveVector, real shearStrain,
   return B;
 }
 
-/*Scales fourier transformed forces in the regular grid to obtain velocities,
-  (Mw·F)_deterministic = σ·St·FFTi·B·FFTf·S·F
-  also adds stochastic fourier noise, see addBrownianNoise
-  Input: gridForces = FFTf·S·F
-  Output:gridVels = B·FFTf·S·F + 1/√σ·√B·dWw
-  See sec. B.2 in [1]
-*/
+/**
+ * Scales Fourier-transformed forces on the regular grid to obtain velocities.
+ *
+ * Computes:
+ *   (Mw * F)_deterministic = sigma * St * FFTi * B * FFTf * S * F
+ * Also adds stochastic Fourier noise. See addBrownianNoise.
+ *
+ * Input:
+ *   gridForces = FFTf * S * F
+ * Output:
+ *   gridVels = B * FFTf * S * F + (1 / sqrt(sigma)) * sqrt(B) * dWw
+ * See section B.2 in [1].
+ */
 __global__ void forceFourier2Vel(
     cufftComplex3 *gridForces, /*Input array*/
     cufftComplex3 *gridVels,   /*Output array, can be the same as input*/
@@ -136,9 +152,14 @@ __global__ void forceFourier2Vel(
                                 B * gridForces[id]);
 }
 
-/*Compute gaussian complex noise dW, std = prefactor -> ||z||^2 =
- * <x^2>/sqrt(2)+<y^2>/sqrt(2) = prefactor*/
-/*A complex random number for each direction*/
+/**
+ * @brief Computes Gaussian complex noise dW with a given standard deviation.
+ *
+ * The generated complex noise satisfies:
+ *   ||z||^2 = <x^2> / sqrt(2) + <y^2> / sqrt(2) = prefactor
+ *
+ * A complex random number is generated for each direction.
+ */
 __device__ cufftComplex3 generateNoise(real prefactor, uint id, uint seed1,
                                        uint seed2) {
   // Uncomment to use uniform numbers instead of gaussian
@@ -194,16 +215,25 @@ __device__ bool isNyquistWaveNumber(int3 cell, int3 ncells) {
   return nyquist;
 }
 
-/*Computes the long range stochastic velocity term
-  Mw·F + sqrt(Mw)·dWw = σ·St·FFTi·B·FFTf·S·F+ √σ·St·FFTi·√B·dWw =
-  = σ·St·FFTi( B·FFTf·S·F + 1/√σ·√B·dWw)
-  See sec. B.2 in [1]
-  This kernel gets v_k = gridVelsFourier = B·FFtt·S·F as input and adds
-  1/√σ·√B(k)·dWw. Keeping special care that v_k = v*_{N-k}, which implies that
-  dWw_k = dWw*_{N-k}
-*/
+/**
+ * @brief Computes the long-range stochastic velocity term:
+ * \f[
+ * M_w \cdot F + \sqrt{M_w} \cdot dW_w = \sigma \cdot \text{St} \cdot
+ * \text{FFTi} \cdot B \cdot \text{FFTf} \cdot S \cdot F +
+ * \sqrt{\sigma} \cdot \text{St} \cdot \text{FFTi} \cdot \sqrt{B} \cdot dW_w =
+ * \sigma \cdot \text{St} \cdot \text{FFTi} \left( B \cdot \text{FFTf} \cdot S
+ * \cdot F + \frac{1}{\sqrt{\sigma}} \cdot \sqrt{B} \cdot dW_w \right)
+ * \f]
+ * See section B.2 in [1].
+ *
+ * This kernel receives \f$v_k = \text{gridVelsFourier} = B \cdot \text{FFTf}
+ * \cdot S \cdot F\f$ as input and adds the noise term
+ * \f$\frac{1}{\sqrt{\sigma}} \cdot \sqrt{B(k)} \cdot dW_w\f$. Special care is
+ * taken so that
+ * \f$v_k = v^*_{N-k}\f$, implying \f$dW_{w,k} = dW^*_{w, N-k}\f$.
+ */
 __global__ void fourierBrownianNoise(cufftComplex3 *gridVelsFourier, Grid grid,
-                                     real prefactor, /* sqrt(2·T/dt)*/
+                                     real prefactor, /* sqrt(2T/dt)*/
                                      real shearStrain, real hydrodynamicRadius,
                                      real viscosity, real split, real eta,
                                      uint seed1, uint seed2) {
@@ -233,7 +263,7 @@ __global__ void fourierBrownianNoise(cufftComplex3 *gridVelsFourier, Grid grid,
   const bool nyquist = isNyquistWaveNumber(cell, nk);
   if (nyquist) {
     /*Nyquist points are their own conjugates, so they must be real.
-      ||r||^2 = <x^2> = ||Real{z}||^2 = <Real{z}^2>·sqrt(2) =  prefactor*/
+      ||r||^2 = <x^2> = ||Real{z}||^2 = <Real{z}^2>*sqrt(2) =  prefactor*/
     constexpr real nqsc = real(1.41421356237310); // sqrt(2)
     noise.x.x *= nqsc;
     noise.x.y = 0;
@@ -242,7 +272,7 @@ __global__ void fourierBrownianNoise(cufftComplex3 *gridVelsFourier, Grid grid,
     noise.z.x *= nqsc;
     noise.z.y = 0;
   }
-  /*Z = sqrt(B)·(I-k^k)·dW*/
+  /*Z = sqrt(B)*(I-k^k)*dW*/
   { // Compute for v_k wave number
     const int3 ik = indexToWaveNumber(id, nk);
     const real3 k = waveNumberToWaveVector(ik, grid.box.boxSize);
@@ -304,7 +334,7 @@ public:
     System::log<System::MESSAGE>("[BDHI::PSE] Box Size: %f %f %f",
                                  box.boxSize.x, box.boxSize.y, box.boxSize.z);
     System::log<System::MESSAGE>(
-        "[BDHI::PSE] Unitless splitting factor ξ·a: %f",
+        "[BDHI::PSE] Unitless splitting factor xi*a: %f",
         psi * par.hydrodynamicRadius);
     const int3 n = grid.cellDim;
     System::log<System::MESSAGE>("[BDHI::PSE] Far range grid size: %d %d %d",
@@ -316,10 +346,18 @@ public:
     cufftDestroy(cufft_plan_forward);
   }
 
-  /*Far contribution of M·F and B·dW
-    Mw·F + sqrt(Mw)·dWw = σ·St·FFTi·G_k·FFTf·S·F+ √σ·St·FFTi·√G_k·dWw =
-    = σ·St·FFTi( G_k·FFTf·S·F + 1/√σ·√G_k·dWw)
-  */
+  /**
+   * @brief Computes the far-field contribution of \f{M \cdot F\f} and \f{B
+   * \cdot dW\f}:
+   * \f[
+   * M_w \cdot F + \sqrt{M_w} \cdot dW_w = \sigma \cdot \text{St} \cdot
+   * \text{FFTi} \cdot G_k \cdot \text{FFTf} \cdot S \cdot F +
+   * \sqrt{\sigma} \cdot \text{St} \cdot \text{FFTi} \cdot \sqrt{G_k} \cdot dW_w
+   * =
+   * \sigma \cdot \text{St} \cdot \text{FFTi} \left( G_k \cdot \text{FFTf} \cdot
+   * S \cdot F + \frac{1}{\sqrt{\sigma}} \cdot \sqrt{G_k} \cdot dW_w \right)
+   * \f]
+   */
   void computeHydrodynamicDisplacements(real4 *pos, real4 *forces, real3 *Mv,
                                         int numberParticles, real temperature,
                                         real prefactor, cudaStream_t st);
@@ -348,10 +386,10 @@ private:
   void initializeKernel(real tolerance);
   void initializeGrid(real tolerance);
 
-  // Computes S·F
+  // Computes SF
   auto spreadForce(real4 *pos, real4 *forces, int numberParticles,
                    cudaStream_t st) {
-    /*Spread force on particles to grid positions -> S·F*/
+    /*Spread force on particles to grid positions -> SF */
     System::log<System::DEBUG2>("[BDHI::PSE] Particles to grid");
     // auto force = pd->getForce(access::location::gpu, access::mode::read);
     auto force_r3 = thrust::make_transform_iterator(forces, detail::ToReal3());
@@ -380,7 +418,7 @@ private:
         (cufftComplex *)thrust::raw_pointer_cast(gridVelsFourier.data());
     cufftSetStream(cufft_plan_forward, st);
     /*Take the grid spreaded forces and apply take it to wave space ->
-     * FFTf·S·F*/
+     * FFTf*S*F*/
     CufftSafeCall(cufftExecReal2Complex<real>(cufft_plan_forward, d_gridVels,
                                               d_gridVelsFourier));
     return gridVelsFourier;
@@ -391,7 +429,7 @@ private:
                        cudaStream_t st) {
     System::log<System::DEBUG2>("[BDHI::PSE] Wave space velocity scaling");
     /*Scale the wave space grid forces, transforming in velocities ->
-     * B·FFT·S·F*/
+     * B*FFT*S*F*/
     auto d_gridVelsFourier =
         (cufftComplex3 *)thrust::raw_pointer_cast(gridVelsFourier.data());
     const int3 n = grid.cellDim;
@@ -403,17 +441,17 @@ private:
     CudaCheckError();
   }
 
-  // Returns G_k·FFT(S·F)
+  // Returns G_k*FFT(S*F)
   auto deterministicPart(real4 *pos, real4 *forces, int numberParticles,
                          cudaStream_t st) {
     // In the absence of forces there is no need to compute the deterministic
     // part
     if (forces) {
-      // S·F
+      // S*F
       auto gridVels = spreadForce(pos, forces, numberParticles, st);
-      // FFT(S·F)
+      // FFT(S*F)
       auto gridVelsFourier = forwardTransformForces(gridVels, st);
-      // G_k·FFT(S·F)
+      // G_k*FFT(S*F)
       convolveFourier(gridVelsFourier, st);
       return gridVelsFourier;
     } else {
@@ -425,14 +463,14 @@ private:
     }
   }
 
-  // Adds the stochastic part in Fourier space ( 1/dV sqrt(G_k)·dW )
+  // Adds the stochastic part in Fourier space ( 1/dV sqrt(G_k)*dW )
   void addBrownianNoise(cached_vector<cufftComplex3> &gridVelsFourier,
                         real temperature, real prefactor, cudaStream_t st) {
     // eq 19 and beyond in [1].
     // The sqrt(2*T/dt) factor needs to be here because far noise is summed to
-    // the M·F term.
-    /*Add the stochastic noise to the fourier velocities if T>0 -> 1/√σ·√B·dWw
-     */
+    // the M*F term.
+    /*Add the stochastic noise to the fourier velocities if T>0 -> 1/sqrt(sigma)*sqrt(B)*dWw
+    */
     if (temperature > real(0.0)) {
       auto d_gridVelsFourier =
           (cufftComplex3 *)thrust::raw_pointer_cast(gridVelsFourier.data());
@@ -443,10 +481,10 @@ private:
       real noise_prefactor = prefactor * sqrt(2 * temperature / (dV));
       int Nthreads = 128;
       int Nblocks = (n.z * n.y * (n.x / 2 + 1)) / Nthreads + 1;
-      // In: B·FFT·S·F -> Out: B·FFT·S·F + 1/√σ·√B·dWw
+      // In: B*FFT*S*F -> Out: B*FFT*S*F + 1/sqrt(sigma)*sqrt(B)*dWw
       detail::fourierBrownianNoise<<<Nblocks, Nthreads, 0, st>>>(
           d_gridVelsFourier, grid,
-          noise_prefactor, // 1/√σ· sqrt(2*T/dt),
+          noise_prefactor, // 1/sqrt(sigma) * sqrt(2*T/dt),
           shearStrain, hydrodynamicRadius, viscosity, psi, eta,
           seed, // Saru needs two seeds apart from thread id
           seed2);
@@ -467,20 +505,20 @@ private:
     auto d_gridVelsFourier =
         (cufftComplex *)thrust::raw_pointer_cast(gridVelsFourier.data());
     cufftSetStream(cufft_plan_inverse, st);
-    /*Take the fourier velocities back to real space ->  FFTi·(B·FFT·S·F +
-     * 1/√σ·√B·dWw )*/
+    /*Take the fourier velocities back to real space ->  FFTi*(B*FFT*S*F +
+     * 1/sqrt(sigma)*sqrt(B)*dWw )*/
     CufftSafeCall(cufftExecComplex2Real<real>(cufft_plan_inverse,
                                               d_gridVelsFourier, d_gridVels));
     return gridVels;
   }
 
-  // Computes J·v. Interpolates the velocities at the particles positions
+  // Computes J*v. Interpolates the velocities at the particles positions
   void interpolateVelocity(cached_vector<real3> &gridVels, real4 *pos,
                            real3 *MF, int numberParticles, cudaStream_t st) {
     System::log<System::DEBUG2>("[BDHI::PSE] Grid to particles");
     /*Interpolate the real space velocities back to the particle positions ->
-      Output: Mv = Mw·F + sqrt(2*T/dt)·√Mw·dWw = σ·St·FFTi·(B·FFT·S·F +
-      1/√σ·√B·dWw )*/
+      Output: Mv = Mw*F + sqrt(2*T/dt)*sqrt(Mw)dWw = sigma*St*FFTi*(B*FFT*S*F +
+      1/sqrt(sigma)*sqrt(B)*dWw )*/
     auto d_gridVels = (real3 *)thrust::raw_pointer_cast(gridVels.data());
     IBM<Kernel> ibm(kernel, grid);
     ibm.gather(pos, MF, d_gridVels, numberParticles, st);
@@ -488,9 +526,9 @@ private:
   }
 };
 
-/*Far contribution of M·F and B·dW
-  Mw·F + sqrt(Mw)·dWw = σ·St·FFTi·G_k·FFTf·S·F+ √σ·St·FFTi·√G_k·dWw =
-  = σ·St·FFTi( G_k·FFTf·S·F + 1/√σ·√G_k·dWw)
+/*Far contribution of M*F and B*dW
+  Mw*F + sqrt(Mw)*dWw = sigma*St*FFTi*G_k*FFTf*S*F+ sqrt(sigma)*St*FFTi*sqrt(G_k)dWw =
+  = sigma*St*FFTi( G_k*FFTf*S*F + 1/sqrt(sigma)*sqrt(G_k)*dWw)
 */
 void FarField::computeHydrodynamicDisplacements(real4 *pos, real4 *forces,
                                                 real3 *MF, int numberParticles,
@@ -499,10 +537,10 @@ void FarField::computeHydrodynamicDisplacements(real4 *pos, real4 *forces,
                                                 cudaStream_t st) {
   System::log<System::DEBUG1>("[BDHI::PSE] Computing MF wave space....");
   System::log<System::DEBUG2>("[BDHI::PSE] Setting vels to zero...");
-  // G_k·FFT(S·F)
+  // G_k*FFT(S*F)
   // The computation is skipped if the forces are not provided (nullptr)
   auto gridVelsFourier = deterministicPart(pos, forces, numberParticles, st);
-  // 1/√σ·√G_k·dWw
+  // 1/sqrt(sigma)*sqrt(G_k)*dWw
   // The computation is skipped if temperature is zero
   addBrownianNoise(gridVelsFourier, temperature, prefactor, st);
   // FFTi
@@ -566,7 +604,7 @@ void FarField::initializeKernel(real tolerance) {
   /*Grid spreading/interpolation parameters*/
   /*Gaussian spreading/interpolation kernel support points neighbour distance
     See eq. 19 and sec 4.1 in [2]*/
-  // m = C·sqrt(pi·P), from sec 4.1 we choose C=0.976
+  // m = C*sqrt(pi*P), from sec 4.1 we choose C=0.976
   constexpr double C = 0.976;
   double m = 1;
   /*I have empirically found that 0.1*tolerance here gives the desired overal

--- a/src/Integrator/BDHI/PSE/FarField.cuh
+++ b/src/Integrator/BDHI/PSE/FarField.cuh
@@ -469,8 +469,9 @@ private:
     // eq 19 and beyond in [1].
     // The sqrt(2*T/dt) factor needs to be here because far noise is summed to
     // the M*F term.
-    /*Add the stochastic noise to the fourier velocities if T>0 -> 1/sqrt(sigma)*sqrt(B)*dWw
-    */
+    /*Add the stochastic noise to the fourier velocities if T>0 ->
+     * 1/sqrt(sigma)*sqrt(B)*dWw
+     */
     if (temperature > real(0.0)) {
       auto d_gridVelsFourier =
           (cufftComplex3 *)thrust::raw_pointer_cast(gridVelsFourier.data());
@@ -527,8 +528,9 @@ private:
 };
 
 /*Far contribution of M*F and B*dW
-  Mw*F + sqrt(Mw)*dWw = sigma*St*FFTi*G_k*FFTf*S*F+ sqrt(sigma)*St*FFTi*sqrt(G_k)dWw =
-  = sigma*St*FFTi( G_k*FFTf*S*F + 1/sqrt(sigma)*sqrt(G_k)*dWw)
+  Mw*F + sqrt(Mw)*dWw = sigma*St*FFTi*G_k*FFTf*S*F+
+  sqrt(sigma)*St*FFTi*sqrt(G_k)dWw = = sigma*St*FFTi( G_k*FFTf*S*F +
+  1/sqrt(sigma)*sqrt(G_k)*dWw)
 */
 void FarField::computeHydrodynamicDisplacements(real4 *pos, real4 *forces,
                                                 real3 *MF, int numberParticles,

--- a/src/Integrator/BDHI/PSE/NearField.cuh
+++ b/src/Integrator/BDHI/PSE/NearField.cuh
@@ -172,7 +172,8 @@ template <class vtype> struct RPYNearTransverser {
      * elements of v*/
     /*This expression is a little obfuscated, Mr_ij*vj*/
     /*
-      Mr = (f(r)*I+(g(r)-f(r))*r(diadic)r)/(6*pi*vis*a) - > (M*v)_beta = (f(r)*v_beta
+      Mr = (f(r)*I+(g(r)-f(r))*r(diadic)r)/(6*pi*vis*a) - > (M*v)_beta =
+      (f(r)*v_beta
       + (g(r)-f(r))*v*(r(diadic)r))/(6*pi*vis*a) Where f and g are the RPY
       coefficients, which are already divided by 6*pi*vis*a in the table.
     */

--- a/src/Integrator/BDHI/PSE/NearField.cuh
+++ b/src/Integrator/BDHI/PSE/NearField.cuh
@@ -102,13 +102,13 @@ private:
 };
 
 namespace pse_ns {
-/*Compute the product M_nearv = M_near·v by transversing a neighbour list
+/*Compute the product M_nearv = M_near*v by transversing a neighbour list
 
   This operation can be seen as an sparse MatrixVector product.
-  Mv_i = sum_j ( Mr_ij·vj )
+  Mv_i = sum_j ( Mr_ij*vj )
 */
 /*Each thread handles one particle with the other N, including itself*/
-/*That is 3 full lines of M, or 3 elements of M·v per thread, being the x y z of
+/*That is 3 full lines of M, or 3 elements of M*v per thread, being the x y z of
  * ij with j=0:N-1*/
 /*In other words. M is made of NxN boxes of size 3x3,
   defining the x,y,z mobility between particle pairs,
@@ -122,7 +122,7 @@ template <class vtype> struct RPYNearTransverser {
   typedef real3 infoType;
 
   RPYNearTransverser(vtype *v, real3 *Mv,
-                     /*RPY_near(r) = F(r)·(I-r^r) + G(r)·r^r*/
+                     /*RPY_near(r) = F(r)*(I-r^r) + G(r)*r^r*/
                      TabulatedFunction<real2> FandG, real rcut, Box box,
                      real shearStrain)
       : v(v), Mv(Mv), FandG(FandG), box(box), shearStrain(shearStrain) {
@@ -149,7 +149,7 @@ template <class vtype> struct RPYNearTransverser {
     rij.x -= Lx * round(rij.x / Lx);
     return rij;
   }
-  /*Compute the dot product Mr_ij(3x3)·vj(3)*/
+  /*Compute the dot product Mr_ij(3x3)*vj(3)*/
   inline __device__ computeType compute(const real4 &pi, const real4 &pj,
                                         const infoType &vi,
                                         const infoType &vj) {
@@ -158,28 +158,28 @@ template <class vtype> struct RPYNearTransverser {
     if (r2 >= rcut2)
       return real3();
     /*Fetch RPY coefficients from a table, see RPYPSE_near*/
-    /* Mreal(r) = (F(r)·I + (G(r)-F(r))·rr)/(6*pi*vis*a) */
+    /* Mreal(r) = (F(r)*I + (G(r)-F(r))*rr)/(6*pi*vis*a) */
     // f and g are divided by 6*pi*vis*a in the texture
     const real2 fg = FandG.get<cub::LOAD_LDG>(sqrt(r2));
     const real f = fg.x;
     const real g = fg.y;
     /*If i==j */
     if (r2 == real(0.0)) {
-      /*M_ii·vi = F(0)*I·vi/(6*pi*vis*a) */
+      /*M_ii*vi = F(0)*I*vi/(6*pi*vis*a) */
       return f * make_real3(vj);
     }
-    /*Update the result with Mr_ij·vj, the current box dot the current three
+    /*Update the result with Mr_ij*vj, the current box dot the current three
      * elements of v*/
-    /*This expression is a little obfuscated, Mr_ij·vj*/
+    /*This expression is a little obfuscated, Mr_ij*vj*/
     /*
-      Mr = (f(r)*I+(g(r)-f(r))*r(diadic)r)/(6*pi*vis*a) - > (M·v)_ß = (f(r)·v_ß
-      + (g(r)-f(r))·v·(r(diadic)r))/(6*pi*vis*a) Where f and g are the RPY
+      Mr = (f(r)*I+(g(r)-f(r))*r(diadic)r)/(6*pi*vis*a) - > (M*v)_beta = (f(r)*v_beta
+      + (g(r)-f(r))*v*(r(diadic)r))/(6*pi*vis*a) Where f and g are the RPY
       coefficients, which are already divided by 6*pi*vis*a in the table.
     */
     const real invr2 = real(1.0) / r2;
     const real gmfv = (g - f) * dot(rij, vj) * invr2;
-    /*gmfv = (g(r)-f(r))·( vx·rx + vy·ry + vz·rz )*/
-    /*((g(r)-f(r))·v·(r(diadic)r) )_ß = gmfv·r_ß*/
+    /*gmfv = (g(r)-f(r))*( vx*rx + vy*ry + vz*rz )*/
+    /*((g(r)-f(r))*v*(r(diadic)r) )_beta = gmfv*r_beta*/
     return make_real3(f * vj + gmfv * rij);
   }
 
@@ -194,11 +194,11 @@ template <class vtype> struct RPYNearTransverser {
   real shearStrain;
 };
 
-/*LanczosAlgorithm needs a functor that computes the product M·v*/
+/*LanczosAlgorithm needs a functor that computes the product M*v*/
 /*Dotctor takes a list transverser and a cell list on construction,
-  and the operator () takes an array v and returns the product M·v*/
+  and the operator () takes an array v and returns the product M*v*/
 struct Dotctor : lanczos::MatrixDot {
-  /*Dotctor uses the same transverser as in Mr·F*/
+  /*Dotctor uses the same transverser as in Mr*F*/
   using myTransverser = RPYNearTransverser<real3>;
   myTransverser Mv_tr;
   shared_ptr<NearField::NeighbourList> cl;
@@ -268,7 +268,7 @@ void NearField::computeStochasticDisplacements(real3 *BdW, real temperature,
   }
   int numberParticles = pg->getNumberParticles();
   pse_ns::Dotctor Mvdot_near(tr, cl, numberParticles, st);
-  /*Lanczos algorithm to compute M_near^1/2 · noise. See LanczosAlgorithm.cuh*/
+  /*Lanczos algorithm to compute M_near^1/2 * noise. See LanczosAlgorithm.cuh*/
   uninitialized_cached_vector<real3> noise(numberParticles);
   const auto id_tr = thrust::make_counting_iterator<uint>(0);
   const uint seed2 = pg->getParticleData()->getSystem()->rng().next32();

--- a/src/Integrator/BrownianDynamics.cuh
+++ b/src/Integrator/BrownianDynamics.cuh
@@ -1,10 +1,10 @@
-/*Raul P. Pelaez 2017-2020. Brownian Dynamics integrators
+/**Raul P. Pelaez 2017-2020. Brownian Dynamics integrators
 
   Solves the following differential equation:
-      X[t+dt] = dt(K·X[t]+M·F[t]) + sqrt(2*Tdt)·dW·B
+      X[t+dt] = dt(KX[t]+MF[t]) + sqrt(2*Tdt)*dW B
    Being:
      X - Positions
-     M - Self Diffusion  coefficient -> 1/(6·pi·vis·radius)
+     M - Self Diffusion  coefficient -> 1/(6 \pi*viscosity*radius)
      K - Shear matrix
      dW- Noise vector
      B - sqrt(M)

--- a/src/Integrator/Hydro/BDHI_quasi2D.cu
+++ b/src/Integrator/Hydro/BDHI_quasi2D.cu
@@ -282,9 +282,9 @@ template <class HydroKernel> void BDHI2D<HydroKernel>::convolveFourier() {
   forwardTransformVelocities();
   // In: FFT*S*F -> Out: B*FFT*S*F
   applyGreenFunctionConvolutionFourier();
-  // In: B*FFT*S*F -> Out: B*FFT*S*F + 1/√σ*√B*dWw
+  // In: B*FFT*S*F -> Out: B*FFT*S*F + 1/sqrt(sigma)*sqrt(B)*dWw
   addStochastichTermFourier();
-  // In: B*FFT*S*F + 1/√σ*√B*dWw -> Out FFTi*(B*FFT*S*F + 1/√σ*√B*dWw )
+  // In: B*FFT*S*F + 1/sqrt(sigma)*sqrt(B)*dWw -> Out FFTi*(B*FFT*S*F + 1/sqrt(sigma)*sqrt(B)*dWw )
   inverseTransformVelocities();
   CudaCheckError();
 }
@@ -451,7 +451,7 @@ void BDHI2D<HydroKernel>::applyGreenFunctionConvolutionFourier() {
 
 template <class HydroKernel>
 void BDHI2D<HydroKernel>::addStochastichTermFourier() {
-  /*Add if T>0 -> 1/√σ*√B*dWw */
+  /*Add if T>0 -> 1/sqrt(sigma)*sqrt(B)*dWw */
   if (temperature > 0) {
     auto d_gridVels =
         (cufftComplex2 *)thrust::raw_pointer_cast(gridVelsFourier.data());

--- a/src/Integrator/Hydro/BDHI_quasi2D.cu
+++ b/src/Integrator/Hydro/BDHI_quasi2D.cu
@@ -278,13 +278,13 @@ template <class HydroKernel> void BDHI2D<HydroKernel>::spreadParticleForces() {
 
 template <class HydroKernel> void BDHI2D<HydroKernel>::convolveFourier() {
   sys->log<System::DEBUG2>("[BDHI::BDHI2D] Wave space convolution");
-  // In: S·F -> Out: FFT·S·F
+  // In: S*F -> Out: FFT*S*F
   forwardTransformVelocities();
-  // In: FFT·S·F -> Out: B·FFT·S·F
+  // In: FFT*S*F -> Out: B*FFT*S*F
   applyGreenFunctionConvolutionFourier();
-  // In: B·FFT·S·F -> Out: B·FFT·S·F + 1/√σ·√B·dWw
+  // In: B*FFT*S*F -> Out: B*FFT*S*F + 1/√σ*√B*dWw
   addStochastichTermFourier();
-  // In: B·FFT·S·F + 1/√σ·√B·dWw -> Out FFTi·(B·FFT·S·F + 1/√σ·√B·dWw )
+  // In: B*FFT*S*F + 1/√σ*√B*dWw -> Out FFTi*(B*FFT*S*F + 1/√σ*√B*dWw )
   inverseTransformVelocities();
   CudaCheckError();
 }
@@ -451,7 +451,7 @@ void BDHI2D<HydroKernel>::applyGreenFunctionConvolutionFourier() {
 
 template <class HydroKernel>
 void BDHI2D<HydroKernel>::addStochastichTermFourier() {
-  /*Add if T>0 -> 1/√σ·√B·dWw */
+  /*Add if T>0 -> 1/√σ*√B*dWw */
   if (temperature > 0) {
     auto d_gridVels =
         (cufftComplex2 *)thrust::raw_pointer_cast(gridVelsFourier.data());

--- a/src/Integrator/Hydro/BDHI_quasi2D.cu
+++ b/src/Integrator/Hydro/BDHI_quasi2D.cu
@@ -284,7 +284,8 @@ template <class HydroKernel> void BDHI2D<HydroKernel>::convolveFourier() {
   applyGreenFunctionConvolutionFourier();
   // In: B*FFT*S*F -> Out: B*FFT*S*F + 1/sqrt(sigma)*sqrt(B)*dWw
   addStochastichTermFourier();
-  // In: B*FFT*S*F + 1/sqrt(sigma)*sqrt(B)*dWw -> Out FFTi*(B*FFT*S*F + 1/sqrt(sigma)*sqrt(B)*dWw )
+  // In: B*FFT*S*F + 1/sqrt(sigma)*sqrt(B)*dWw -> Out FFTi*(B*FFT*S*F +
+  // 1/sqrt(sigma)*sqrt(B)*dWw )
   inverseTransformVelocities();
   CudaCheckError();
 }

--- a/src/Integrator/Hydro/ICM.cu
+++ b/src/Integrator/Hydro/ICM.cu
@@ -917,7 +917,7 @@ void ICM::printMessages(Parameters par) {
     real v = sqrt(temperature / (density * dx * dx * dx));
     real a = v * dt / dx;
     real b = viscosity * dt / (density * dx * dx);
-    sys->log<System::MESSAGE>("[Hydro::ICM] CFL numbers: α = %f; β = %f", a, b);
+    sys->log<System::MESSAGE>("[Hydro::ICM] CFL numbers: alpha = %f; beta = %f", a, b);
     if (a > 1) {
       sys->log<System::WARNING>("[Hydro::ICM] CFL numbers above 1 can cause "
                                 "numerical issues and poor accuracy.");

--- a/src/Integrator/Hydro/ICM.cu
+++ b/src/Integrator/Hydro/ICM.cu
@@ -917,7 +917,8 @@ void ICM::printMessages(Parameters par) {
     real v = sqrt(temperature / (density * dx * dx * dx));
     real a = v * dt / dx;
     real b = viscosity * dt / (density * dx * dx);
-    sys->log<System::MESSAGE>("[Hydro::ICM] CFL numbers: alpha = %f; beta = %f", a, b);
+    sys->log<System::MESSAGE>("[Hydro::ICM] CFL numbers: alpha = %f; beta = %f",
+                              a, b);
     if (a > 1) {
       sys->log<System::WARNING>("[Hydro::ICM] CFL numbers above 1 can cause "
                                 "numerical issues and poor accuracy.");

--- a/src/Integrator/Hydro/ICM.cuh
+++ b/src/Integrator/Hydro/ICM.cuh
@@ -21,7 +21,7 @@ hydrodynamic radius given here cannot be enforced exactly, rather the most
 approximate one will be computed by selecting an appropiate cellDimension (which
 will be an FFT wise number). par.hydrodynamicRadius = 1.0;
 //Instead of the hydrodynamic radius the cell dimensions can be provided
-directly. Giving rh~0.91·L/cellDim
+directly. Giving rh~0.91*L/cellDim
 //par.cells=make_int3(64,64,64); //cells.z == 1 means 2D
 //In any case a message will be issued with the used hydrodynamic radius.
 par.dt = 0.01;
@@ -45,11 +45,11 @@ A brief summary of the algorithm:
 
 eq. 36 in [1] can be rewritten as:
 
-\tilde{\vec{v}}^{n+1} = \mathcal{L}^{-1}·\vec{g} -> fluid velocity
+\tilde{\vec{v}}^{n+1} = \mathcal{L}^{-1}*\vec{g} -> fluid velocity
 
 Where:
 
-\mathcal{L}^{-1} = (\rho/dt·\bf{I} - \eta/2 L)^{-1} · P
+\mathcal{L}^{-1} = (\rho/dt*\bf{I} - \eta/2 L)^{-1} * P
 \vec{g} = (\rho/dt\bf{I} + \eta/2 L)\vec{v}^n + DW^n + SF^{n+1/2} - D(\rho
 \vec{v}\vec{v}^T)^n+1/2 -> fluid forcing ^ noise                  ^ advection P
 = \bf{I} - G(DG)^-1 D -> projection to divergence free space
@@ -61,8 +61,8 @@ S: Spreading operator (transmits particle properties to fluid)
 W: Symmetric noise tensor, Gaussian numbers with mean 0 and std 1
 
 On the other hand the particles and fluid are coupled with:
-\vec{u}^n = J·\vec{v}
-Where J is the interpolation operator defined as J^T = dV·S
+\vec{u}^n = J*\vec{v}
+Where J is the interpolation operator defined as J^T = dV*S
 Where dV is the volume of a grid cell.
 
 The particles are updated following the mid point (predictor-corrector) scheme
@@ -71,7 +71,7 @@ developed in [1].
 About J and S:
 
 S_cellj = sum_i=0^N{\delta(ri-r_cellj)} ->particles to fluid
-J_i = dV·sum_j=0^ncells{\delta(ri-r_cellj)}->fluid to particles
+J_i = dV*sum_j=0^ncells{\delta(ri-r_cellj)}->fluid to particles
 
 Where \delta is an spreading kernel (smeared delta).
 The default kernel used is the 3-point Peskin kernel, see IBM_kernels.cuh.

--- a/src/Integrator/Hydro/ICM_Compressible.cuh
+++ b/src/Integrator/Hydro/ICM_Compressible.cuh
@@ -352,8 +352,8 @@ private:
     real maxv = std::max({maxvx, maxvy, maxvz});
     real a_v = maxv * par.dt / h;
     System::log<System::MESSAGE>(
-        "[ICM_Compressible] Advective CFL Numbers: alpha_c ~ %g; alpha_v ~ %g", a_c,
-        a_v);
+        "[ICM_Compressible] Advective CFL Numbers: alpha_c ~ %g; alpha_v ~ %g",
+        a_c, a_v);
     real maxDensity = *thrust::max_element(currentFluid.density.begin(),
                                            currentFluid.density.end());
     real kinematicViscosity = par.shearViscosity / maxDensity;
@@ -362,9 +362,10 @@ private:
                                             par.hydrodynamicRadius);
     real b_c = selfDiffusion * par.dt / (h * h);
     System::log<System::MESSAGE>(
-        "[ICM_Compressible] Viscous CFL Numbers: beta ~ %g; beta_c ~ %g", b, b_c);
-    System::log<System::MESSAGE>("[ICM_Compressible] Fluid cell Re=alpha_c/beta=%g",
-                                 a_c / b);
+        "[ICM_Compressible] Viscous CFL Numbers: beta ~ %g; beta_c ~ %g", b,
+        b_c);
+    System::log<System::MESSAGE>(
+        "[ICM_Compressible] Fluid cell Re=alpha_c/beta=%g", a_c / b);
     real Sc = kinematicViscosity / selfDiffusion;
     System::log<System::MESSAGE>("[ICM_Compressible] Schmidt number: %g", Sc);
   }

--- a/src/Integrator/Hydro/ICM_Compressible.cuh
+++ b/src/Integrator/Hydro/ICM_Compressible.cuh
@@ -352,7 +352,7 @@ private:
     real maxv = std::max({maxvx, maxvy, maxvz});
     real a_v = maxv * par.dt / h;
     System::log<System::MESSAGE>(
-        "[ICM_Compressible] Advective CFL Numbers: α_c ~ %g; α_v ~ %g", a_c,
+        "[ICM_Compressible] Advective CFL Numbers: alpha_c ~ %g; alpha_v ~ %g", a_c,
         a_v);
     real maxDensity = *thrust::max_element(currentFluid.density.begin(),
                                            currentFluid.density.end());
@@ -362,8 +362,8 @@ private:
                                             par.hydrodynamicRadius);
     real b_c = selfDiffusion * par.dt / (h * h);
     System::log<System::MESSAGE>(
-        "[ICM_Compressible] Viscous CFL Numbers: β ~ %g; β_c ~ %g", b, b_c);
-    System::log<System::MESSAGE>("[ICM_Compressible] Fluid cell Re=α_c/β=%g",
+        "[ICM_Compressible] Viscous CFL Numbers: beta ~ %g; beta_c ~ %g", b, b_c);
+    System::log<System::MESSAGE>("[ICM_Compressible] Fluid cell Re=alpha_c/beta=%g",
                                  a_c / b);
     real Sc = kinematicViscosity / selfDiffusion;
     System::log<System::MESSAGE>("[ICM_Compressible] Schmidt number: %g", Sc);

--- a/src/Integrator/Hydro/ICM_Compressible/SpatialDiscretization.cuh
+++ b/src/Integrator/Hydro/ICM_Compressible/SpatialDiscretization.cuh
@@ -22,18 +22,19 @@ h is the size of a cell.
 
 This rules result in the values assigned to a cell sometimes being defined in
 strange places. The sketch below represents all the values owning to a certain
-cell, \vec{i} (with center defined at ○). Unintuitively, some quantities asigned
+cell, \vec{i} (with center defined at O). Unintuitively, some quantities asigned
 to cell \vec{i} lie in the neighbouring cells (represented below is also cell
 \vec{i} + (1,0,0)).
 
             <------h---->
-+-----⬒-----▽-----------+  | ○: p (Cell center, at \vec{r}_\vec{i})
-|      	    |	       	|    ◨: v^x
-|      	    |	       	|  | ⬒: v^y
-|     ○	    ◨  	  △    	|
-| 	    |  	       	|  | △: E^{xx}
-|      	    |		|    ▽: E^{xy}
-+-----------+-----------+  |
++-----[ ]------v-----------+  | O: p (Cell center, at \vec{r}_\vec{i})
+|              |           |    # : v^x
+|              |           |  | [ ]: v^y
+|     O        #     ^     |
+|              |           |  | ^: E^{xx}
+|              |           |    v: E^{xy}
++-------------+-----------+  |
+
 
 Naturally, this discretisation requires special handling of the discretized
 versions of the (differential) operators.

--- a/src/Integrator/Hydro/LBM.cu
+++ b/src/Integrator/Hydro/LBM.cu
@@ -7,7 +7,7 @@ References:
 
 [1] Optimized implementation of the Lattice Boltzmann Method on a graphics
 processing unit towards real-time fluid simulation.  N. Delbosc et al.
-http://dx.doi.org/10.1016/j.camwa.2013.10.002 [2] Accelerating fluid–solid
+http://dx.doi.org/10.1016/j.camwa.2013.10.002 [2] Accelerating fluid-solid
 simulations (Lattice-Boltzmann & Immersed-Boundary) on heterogeneous
 architectures. Pedro Valero-Lara et. al.
 https://hal.archives-ouvertes.fr/hal-01225734

--- a/src/Integrator/MonteCarlo/NVT/Anderson.cu
+++ b/src/Integrator/MonteCarlo/NVT/Anderson.cu
@@ -1,4 +1,4 @@
-/*Raul P. Pelaez 2018-2020. Adapted from Pablo Ibañez Freire's MonteCarlo
+/*Raul P. Pelaez 2018-2020. Adapted from Pablo Ibanez Freire's MonteCarlo
 Anderson code.
 
   This module implements Anderson's Monte Carlo NVT GPU algorithm [1].

--- a/src/Integrator/MonteCarlo/NVT/Anderson.cu
+++ b/src/Integrator/MonteCarlo/NVT/Anderson.cu
@@ -148,7 +148,7 @@ template <class Pot> void Anderson<Pot>::updateJumpSize() {
   sys->log<System::DEBUG>("[MC_NVT::Anderson] Current acceptance ratio: %e",
                           currentAcceptanceRatio);
   sys->log<System::DEBUG>(
-      "[MC_NVT::Anderson] Current step size: %e, %e·cellSize", jumpSize,
+      "[MC_NVT::Anderson] Current step size: %e, %e*cellSize", jumpSize,
       jumpSize / grid.cellSize.x);
 }
 

--- a/src/Integrator/MonteCarlo/NVT/Anderson.cuh
+++ b/src/Integrator/MonteCarlo/NVT/Anderson.cuh
@@ -1,4 +1,4 @@
-/*Raul P. Pelaez 2018-2020. Adapted from Pablo Ibañez Freire's MonteCarlo
+/*Raul P. Pelaez 2018-2020. Adapted from Pablo Ibanez Freire's MonteCarlo
 Anderson code.
 
   This module implements Anderson's Monte Carlo NVT GPU algorithm [1].

--- a/src/Integrator/VerletNVT/GronbechJensen.cu
+++ b/src/Integrator/VerletNVT/GronbechJensen.cu
@@ -20,10 +20,10 @@ namespace GronbechJensen_ns {
 
 // Integrate the movement 0.5 dt and reset the forces in the first step
 // (step==1) Uses the Gronbech Jensen scheme[1]
-//   r[t+dt] = r[t] + b·dt·v[t] + b·dt^2/(2·m) + b·dt/(2·m) · noise[t+dt]
-//   v[t+dt] = a·v[t] + dt/(2·m)·(a·f[t] + f[t+dt]) + b/m·noise[t+dt]
-//  b = 1/( 1 + \gamma·dt/(2·m))
-//  a = (1 - \gamma·dt/(2·m) ) ·b
+//   r[t+dt] = r[t] + b*dt*v[t] + b*dt^2/(2*m) + b*dt/(2*m) * noise[t+dt]
+//   v[t+dt] = a*v[t] + dt/(2*m)*(a*f[t] + f[t+dt]) + b/m*noise[t+dt]
+//  b = 1/( 1 + \gamma*dt/(2*m))
+//  a = (1 - \gamma*dt/(2*m) ) *b
 //  \gamma = friction*mass
 template <int step>
 __global__ void integrateGPU(real4 *__restrict__ pos, real3 *__restrict__ vel,

--- a/src/Interactor/AngularBondedForces.cuh
+++ b/src/Interactor/AngularBondedForces.cuh
@@ -100,7 +100,7 @@ struct Angular {
     // //sijk cant be zero to avoid division by zero
     // if(sijk<std::numeric_limits<real>::min()) sijk =
     // std::numeric_limits<real>::min(); ampli = -kspring * (acos(cijk) -
-    // ang0)/sijk; //The force amplitude -k·(theta-theta_0)
+    // ang0)/sijk; //The force amplitude -k*(theta-theta_0)
     // ampli = -kspring*(-sijk*cos(ang0)+cijk*sin(ang0))+ang0;
     // //k(1-cos(ang-ang0))
     if (ang0 == real(0.0)) {

--- a/src/Interactor/BondedForces.cuh
+++ b/src/Interactor/BondedForces.cuh
@@ -55,7 +55,7 @@ namespace BondedType {
 
 namespace detail {
 inline __device__ real harmonicForceModulusDivR(real invr, real k, real r0) {
-  const real f = -k * (real(1.0) - r0 * invr); // F = -k·(r-r0)·rvec/r
+  const real f = -k * (real(1.0) - r0 * invr); // F = -k*(r-r0)*rvec/r
   return f;
 }
 

--- a/src/Interactor/NeighbourList/LBVH.cuh
+++ b/src/Interactor/NeighbourList/LBVH.cuh
@@ -44,7 +44,7 @@ https://doi.org/10.1016/j.cpc.2016.02.003 [2] Maximizing Parallelism in the
 Construction of BVHs,Octrees, andk-d Trees, Tero Karras. 2012.
 https://devblogs.nvidia.com/wp-content/uploads/2012/11/karras2012hpg_paper.pdf
    [3] Ray casting using a roped BVH with CUDA. R. Torres, et. al. 2009.
-https://doi.org/10.1145/1980462.1980483 pp. 95–102. [4] Quantized bounding
+https://doi.org/10.1145/1980462.1980483 pp. 95-102. [4] Quantized bounding
 volume hierarchies for neighbor search in molecular simulations on graphics
 processing units. Michael P. Howard, et. al.
 https://doi.org/10.1016/j.commatsci.2019.04.004

--- a/src/Interactor/Potential/Potential.cuh
+++ b/src/Interactor/Potential/Potential.cuh
@@ -54,7 +54,7 @@ struct LJFunctor {
                  (invr6 - real(1.0)) -
              params.shift;
     // if(params.shift != real(0.0)){
-    //   ////With shift, u(r) = lj(r)-lj(rc)  -(r-rc)·(dlj(r)/dr|_rc)
+    //   ////With shift, u(r) = lj(r)-lj(rc)  -(r-rc)*(dlj(r)/dr|_rc)
     //   // real rc = sqrt(params.cutOff2);
     //   // real invrc2 = real(params.sigma2)/(params.cutOff2);
     //   // real invrc6 = invrc2*invrc2*invrc2;

--- a/src/Interactor/SPH.cu
+++ b/src/Interactor/SPH.cu
@@ -4,7 +4,7 @@
 (i.e VerletNVE).
 
   Computes a force on each particle as:
-  Fi = sum_j[  mj·(Pj/rhoj^2 + Pi/rhoi^2 + visij)·grad_i(Wij) ]
+  Fi = sum_j[  mj*(Pj/rhoj^2 + Pi/rhoi^2 + visij)*grad_i(Wij) ]
 
   Where:
     j: The neighbours of i (within a distance given by the support of Wij)
@@ -18,13 +18,13 @@
 See SPH_ns::Kernel
 
   The density on a given particle i is interpolated from its neighbours as:
-   rho_i = sum_j[ mj·Wij ]
+   rho_i = sum_j[ mj*Wij ]
 
   The Pressure is given by an equation-of-state depending on interpolated
-properties of the particles. Currently: Pi = K·(rho_i-rho0)
+properties of the particles. Currently: Pi = K*(rho_i-rho0)
 
   An artificial viscosity is introduced to allow shock phenomena ans stabilize
-the algorithm. visij = -nu( vij·rij)/(rij^2+epsilon) epsilon ~ 0.001 v: velocity
+the algorithm. visij = -nu( vij*rij)/(rij^2+epsilon) epsilon ~ 0.001 v: velocity
     r: particle position
 
 
@@ -76,7 +76,7 @@ template <class Kernel> struct DensityTransverser {
   // Starting density of each particle
   inline __device__ real zero() { return real(0); }
 
-  // rho_i = sum_j( mj · Wij)
+  // rho_i = sum_j( mj * Wij)
   inline __device__ real compute(real4 ri, real4 rj, real massi, real massj) {
     real3 rij = box.apply_pbc(make_real3(rj) - make_real3(ri));
     return massj * kernel(rij, support);
@@ -90,7 +90,7 @@ template <class Kernel> struct DensityTransverser {
 };
 
 // Compute Pressure, this simple functor codes the ideal gas state eq. Pi =
-// K·(rho_i - rho0)
+// K*(rho_i - rho0)
 struct Density2Pressure {
   real gasStiffness, restDensity;
   Density2Pressure(real gasStiffness, real restDensity)
@@ -102,7 +102,7 @@ struct Density2Pressure {
 };
 
 // Computes artificial viscosity from vij and rij: vis =
-// nu·(vj·rij)/(rij^2+epsilon·h^2)
+// nu*(vj*rij)/(rij^2+epsilon*h^2)
 struct ArtificialViscosity {
   real viscosityPrefactor, epsilon;
   ArtificialViscosity(real pre, real e = 0.001)
@@ -115,7 +115,7 @@ struct ArtificialViscosity {
 };
 
 // Compute and sum the force on each particle:
-//  Fi = sum_j( mi·mj·(Pi/rho_i^2 + Pj/rho_j^2)· rij · W(rij)
+//  Fi = sum_j( mi*mj*(Pi/rho_i^2 + Pj/rho_j^2)* rij * W(rij)
 template <class Kernel> struct ForceTransverser {
   Kernel kernel; // Interpolation kernel
   real support;  // Support distance of the kernel

--- a/src/Interactor/SPH.cu
+++ b/src/Interactor/SPH.cu
@@ -33,7 +33,7 @@ TODO:
 
 References:
 [1] Smoothed particle hydrodynamics. JJ Monaghan. Rep. Prog. Phys. 68 (2005)
-1703–1759 doi:10.1088/0034-4885/68/8/R01
+1703-1759 doi:10.1088/0034-4885/68/8/R01
 
  */
 #include "SPH.cuh"

--- a/src/Interactor/SPH.cuh
+++ b/src/Interactor/SPH.cuh
@@ -29,7 +29,7 @@ the algorithm. visij = -nu( vij*rij)/(rij^2+epsilon) epsilon ~ 0.001 v: velocity
 
 References:
 [1] Smoothed particle hydrodynamics. JJ Monaghan. Rep. Prog. Phys. 68 (2005)
-1703–1759 doi:10.1088/0034-4885/68/8/R01
+1703-1759 doi:10.1088/0034-4885/68/8/R01
 
  */
 

--- a/src/Interactor/SPH.cuh
+++ b/src/Interactor/SPH.cuh
@@ -4,7 +4,7 @@
 (i.e VerletNVE).
 
   Computes a force on each particle as:
-  Fi = sum_j[  mj·(Pj/rhoj^2 + Pi/rhoi^2 + visij)·grad_i(Wij) ]
+  Fi = sum_j[  mj*(Pj/rhoj^2 + Pi/rhoi^2 + visij)*grad_i(Wij) ]
 
   Where:
     j: The neighbours of i (within a distance given by the support of Wij)
@@ -18,13 +18,13 @@
 See SPH_ns::Kernel
 
   The density on a given particle i is interpolated from its neighbours as:
-   rho_i = sum_j[ mj·Wij ]
+   rho_i = sum_j[ mj*Wij ]
 
   The Pressure is given by an equation-of-state depending on interpolated
-properties of the particles. Currently: Pi = K·(rho_i-rho0)
+properties of the particles. Currently: Pi = K*(rho_i-rho0)
 
   An artificial viscosity is introduced to allow shock phenomena ans stabilize
-the algorithm. visij = -nu( vij·rij)/(rij^2+epsilon) epsilon ~ 0.001 v: velocity
+the algorithm. visij = -nu( vij*rij)/(rij^2+epsilon) epsilon ~ 0.001 v: velocity
     r: particle position
 
 References:

--- a/src/ParticleData/ParticleData.cuh
+++ b/src/ParticleData/ParticleData.cuh
@@ -228,7 +228,7 @@ public:
 #define GET_PROPERTY_T(Name, name) GET_PROPERTY_R(Name, name);
 #define GET_PROPERTY_R(Name, name)                                             \
   inline auto get##Name(access::location dev, access::mode mode)               \
-      ->decltype(name.data(dev, mode)) {                                       \
+      -> decltype(name.data(dev, mode)) {                                      \
     if (!name.isAllocated())                                                   \
       name.resize(numberParticles);                                            \
     if (!name.isAllocated() or mode == access::mode::write or                  \
@@ -248,7 +248,7 @@ public:
 #define GET_PROPERTY_IF_ALLOC_T(Name, name) GET_PROPERTY_IF_ALLOC_R(Name, name)
 #define GET_PROPERTY_IF_ALLOC_R(Name, name)                                    \
   inline auto get##Name##IfAllocated(access::location dev, access::mode mode)  \
-      ->decltype(name.data(dev, mode)) {                                       \
+      -> decltype(name.data(dev, mode)) {                                      \
     if (!name.isAllocated()) {                                                 \
       decltype(name.data(dev, mode)) tmp;                                      \
       return tmp;                                                              \

--- a/src/ParticleData/ParticleData.cuh
+++ b/src/ParticleData/ParticleData.cuh
@@ -228,7 +228,7 @@ public:
 #define GET_PROPERTY_T(Name, name) GET_PROPERTY_R(Name, name);
 #define GET_PROPERTY_R(Name, name)                                             \
   inline auto get##Name(access::location dev, access::mode mode)               \
-      -> decltype(name.data(dev, mode)) {                                      \
+      ->decltype(name.data(dev, mode)) {                                       \
     if (!name.isAllocated())                                                   \
       name.resize(numberParticles);                                            \
     if (!name.isAllocated() or mode == access::mode::write or                  \
@@ -248,7 +248,7 @@ public:
 #define GET_PROPERTY_IF_ALLOC_T(Name, name) GET_PROPERTY_IF_ALLOC_R(Name, name)
 #define GET_PROPERTY_IF_ALLOC_R(Name, name)                                    \
   inline auto get##Name##IfAllocated(access::location dev, access::mode mode)  \
-      -> decltype(name.data(dev, mode)) {                                      \
+      ->decltype(name.data(dev, mode)) {                                       \
     if (!name.isAllocated()) {                                                 \
       decltype(name.data(dev, mode)) tmp;                                      \
       return tmp;                                                              \

--- a/src/ParticleData/ParticleData.cuh
+++ b/src/ParticleData/ParticleData.cuh
@@ -129,7 +129,7 @@ using connection = nod::connection;
  *
  * The ParticleData class manages particle properties such as position,
  * velocity, mass, charge, force, energy, and more. Properties are allocated
- * lazily — they are only initialized upon first access. It supports both CPU
+ * lazily - they are only initialized upon first access. It supports both CPU
  * and GPU memory access modes and controls exclusive write access to ensure
  * data integrity across computational modules.
  *

--- a/src/misc/LanczosAlgorithm.cuh
+++ b/src/misc/LanczosAlgorithm.cuh
@@ -1,12 +1,12 @@
 /*Raul P. Pelaez 2022. Lanczos Algotihm,
-  Computes the matrix-vector product sqrt(M)·v using a recursive algorithm.
+  Computes the matrix-vector product sqrt(M)*v using a recursive algorithm.
   For that, it requires a functor in which the () operator takes an output real*
 array and an input real* (both device memory) as: inline void operator()(real*
 in_v, real * out_Mv); This function must fill "out" with the result of
-performing the M·v dot product- > out = M·a_v. If M has size NxN and the cost of
-the dot product is O(M). The total cost of the algorithm is O(m·M). Where m <<
-N. If M·v performs a dense M-V product, the cost of the algorithm would be
-O(m·N^2). References: [1] Krylov subspace methods for computing hydrodynamic
+performing the M*v dot product- > out = M*a_v. If M has size NxN and the cost of
+the dot product is O(M). The total cost of the algorithm is O(m*M). Where m <<
+N. If M*v performs a dense M-V product, the cost of the algorithm would be
+O(m*N^2). References: [1] Krylov subspace methods for computing hydrodynamic
 interactions in Brownian dynamics simulations J. Chem. Phys. 137, 064106 (2012);
 doi: 10.1063/1.4742347 Some notes: From what I have seen, this algorithm
 converges to an error of ~1e-3 in a few steps (<5) and from that point a lot of
@@ -34,8 +34,8 @@ struct Solver {
 
   ~Solver();
 
-  // Given a Dotctor that computes a product M·v (where M is handled by Dotctor
-  // ), computes Bv = sqrt(M)·v Returns the number of iterations required to
+  // Given a Dotctor that computes a product M*v (where M is handled by Dotctor
+  // ), computes Bv = sqrt(M)*v Returns the number of iterations required to
   // achieve the requested tolerance B = sqrt(M)
   int run(MatrixDot *dot, real *Bv, const real *v, real tolerance, int N,
           cudaStream_t st = 0);
@@ -48,8 +48,8 @@ struct Solver {
     auto lanczos_dot = createMatrixDotAdaptor(dot);
     return run(lanczos_dot, Bv, v, tolerance, N, st);
   }
-  // Given a Dotctor that computes a product M·v (where M is handled by Dotctor
-  // ), computes Bv = sqrt(M)·v Returns the residual after numberIterations
+  // Given a Dotctor that computes a product M*v (where M is handled by Dotctor
+  // ), computes Bv = sqrt(M)*v Returns the residual after numberIterations
   // iterations B = sqrt(M)
   real runIterations(MatrixDot *dot, real *Bz, const real *z,
                      int numberIterations, int N);

--- a/src/utils/quaternion.cuh
+++ b/src/utils/quaternion.cuh
@@ -174,7 +174,7 @@ QUATTR Quat Quat::getConjugate() const { return Quat(n, -v); }
 /*
    Returns the quaternion that encondes a rotation of ang radians
    around the axis vrot
-   q = (cos(phi/2),vrot·sin(phi/2))
+   q = (cos(phi/2),vrot*sin(phi/2))
  */
 QUATTR Quat rotVec2Quaternion(real3 vrot, real phi) {
   real norm = (dot(vrot, vrot));

--- a/src/utils/tensor.cuh
+++ b/src/utils/tensor.cuh
@@ -1,4 +1,4 @@
-/*Pablo Ibañez 2022. Tensor types and related algebra.
+/*Pablo Ibanez 2022. Tensor types and related algebra.
 
  */
 #ifndef TENSOR_CUH

--- a/test/BDHI/DPStokes/dpstokes_test.cu
+++ b/test/BDHI/DPStokes/dpstokes_test.cu
@@ -247,8 +247,8 @@ TEST(DPStokesIntegrator, ObeysFluctuationDissipationBalanceAtEveryHeight) {
     for (int i = 0; i < navg; i++) {
       pd->getPos(access::cpu, access::write)[0] = {0, 0, z, 0};
       dpstokes_integrator->forwardTime();
-      auto r = (make_real3(
-          pd->getPos(access::cpu, access::read)[0]))-make_real3(0, 0, z);
+      auto r = (make_real3(pd->getPos(access::cpu, access::read)[0])) -
+               make_real3(0, 0, z);
       avg += r * r;
     }
     auto sigma = avg / navg;

--- a/test/BDHI/DPStokes/dpstokes_test.cu
+++ b/test/BDHI/DPStokes/dpstokes_test.cu
@@ -247,8 +247,8 @@ TEST(DPStokesIntegrator, ObeysFluctuationDissipationBalanceAtEveryHeight) {
     for (int i = 0; i < navg; i++) {
       pd->getPos(access::cpu, access::write)[0] = {0, 0, z, 0};
       dpstokes_integrator->forwardTime();
-      auto r = (make_real3(pd->getPos(access::cpu, access::read)[0])) -
-               make_real3(0, 0, z);
+      auto r = (make_real3(
+          pd->getPos(access::cpu, access::read)[0]))-make_real3(0, 0, z);
       avg += r * r;
     }
     auto sigma = avg / navg;

--- a/test/BDHI/FCM/FCM.cu
+++ b/test/BDHI/FCM/FCM.cu
@@ -18,7 +18,7 @@ All output is adimensional.
 #include <vector>
 using namespace uammd;
 
-// FCM kernel M(\vec{r}) = f(r)·I + g(r)·\vec{r}\otimes\vec{r}/r^2
+// FCM kernel M(\vec{r}) = f(r)*I + g(r)*\vec{r}\otimes\vec{r}/r^2
 // M0 = f(0)
 long double f(long double r, double rh, double viscosity) {
   return (1.0 / (8.0 * M_PIl * viscosity * r)) *
@@ -272,10 +272,10 @@ void computePairMobilityMatrix(real3 L, double F, real3 dist, long double *M,
 
 void computePairMobilityOpenBoundary(double *M, real3 rij, double rh,
                                      double viscosity) {
-  // When applying a force \vec{force_i} = (-1)^i·\hat{\beta} to particle i, the
+  // When applying a force \vec{force_i} = (-1)^i*\hat{\beta} to particle i, the
   // velocity of the other particle will be v_\alpha =
-  // M_{alpha\beta}(r)-M_{\alpha\beta}(0) = (f(r)-f(0))·\delta_{\alpha\beta}+
-  // g(r)·r_\alpha*r_\beta/r^2
+  // M_{alpha\beta}(r)-M_{\alpha\beta}(0) = (f(r)-f(0))*\delta_{\alpha\beta}+
+  // g(r)*r_\alpha*r_\beta/r^2
   for (int i = 0; i < 9; i++) {
     M[i] = 0;
   }

--- a/test/BDHI/FCM/tools/fcmMobility.cpp
+++ b/test/BDHI/FCM/tools/fcmMobility.cpp
@@ -1,9 +1,9 @@
 // Raul P. Pelaez 1028. Taken from after eq. 20 in [1]
-//   v = M·F
+//   v = M*F
 //  Put two particles at a distance r, pull particle 0 with Fx = 1 and particle
 //  1 with Fx = -1
 //
-// hydrodynamic force acting on particle 0 -> v = M0·F_0 + M(r)·F_1 = M0-M((r)
+// hydrodynamic force acting on particle 0 -> v = M0*F_0 + M(r)*F_1 = M0-M((r)
 //
 // This code returns:   M0(L)/v = M0(L)/(M0-M(r))
 // References:

--- a/test/BDHI/FIB/FIB.cu
+++ b/test/BDHI/FIB/FIB.cu
@@ -19,7 +19,7 @@ using namespace uammd;
 
 real temperature, viscosity, rh, tolerance;
 
-// RPY kernel M(\vec{r}) = f(r)·I + g(r)·\vec{r}\otimes\vec{r}/r^2
+// RPY kernel M(\vec{r}) = f(r)*I + g(r)*\vec{r}\otimes\vec{r}/r^2
 // M0 = f(0)
 long double f(long double r, long double a = rh) {
   long double M0 = 1 / (6 * M_PIl * viscosity * a);

--- a/test/BDHI/FIB/tools/fcmMobility.cpp
+++ b/test/BDHI/FIB/tools/fcmMobility.cpp
@@ -1,9 +1,9 @@
 // Raul P. Pelaez 1028. Taken from after eq. 20 in [1]
-//   v = M·F
+//   v = M*F
 //  Put two particles at a distance r, pull particle 0 with Fx = 1 and particle
 //  1 with Fx = -1
 //
-// hydrodynamic force acting on particle 0 -> v = M0·F_0 + M(r)·F_1 = M0-M((r)
+// hydrodynamic force acting on particle 0 -> v = M0*F_0 + M(r)*F_1 = M0-M((r)
 //
 // This code returns:   M0(L)/v = M0(L)/(M0-M(r))
 // References:

--- a/test/BDHI/Lanczos_Cholesky/process.cpp
+++ b/test/BDHI/Lanczos_Cholesky/process.cpp
@@ -9,7 +9,7 @@
   In each step of the simulation the displacement of a certain particle, except
   the i=0, will be given by:
 
-  dxi/dt = M·F = M0i = f(r)·I + g(r)/r^2 * (r\diadic r)
+  dxi/dt = M*F = M0i = f(r)*I + g(r)/r^2 * (r\diadic r)
 
   This code computes f(r) and g(r) from the displacements of particles at each
   time step and compares it with the theoretical RPY tensor with particles of

--- a/test/BDHI/PSE/PSE.cu
+++ b/test/BDHI/PSE/PSE.cu
@@ -90,7 +90,7 @@ bool selfMobility_pullForce_test() {
     std::ofstream velout("selfMobility_pullForce.psi" +
                          std::to_string(psi * rh) + ".test");
     velout.precision(2 * sizeof(real));
-    velout << "#L  v/(F·M0)" << endl;
+    velout << "#L  v/(F*M0)" << endl;
     fori(0, NL) {
       real L = L_min + i * ((L_max - L_min) / (real)(NL - 1));
       try {
@@ -130,7 +130,7 @@ double pullForce_pairMobility_measureMobility(real L, real psi, real F) {
   real vel;
   std::ofstream out("pairMobility_pullForce.psi" + std::to_string(psi * rh) +
                     ".test");
-  out << "#distance   M0/(F·v)" << endl;
+  out << "#distance   M0/(F*v)" << endl;
   real minr = 0.01;
   real maxr = L * 0.5;
   int nPoints = 2000;
@@ -163,7 +163,7 @@ double pullForce_pairMobility_measureMobility(real L, real psi, real F) {
 bool deterministicPairMobility_test() {
   int Npsi = 10;
   std::vector<real2> velocities(Npsi);
-  // Keep psi·a constant
+  // Keep psi*a constant
   real psi_min = 0.1 / rh;
   real psi_max = 1.0 / rh;
   real F = 1;
@@ -281,7 +281,7 @@ double3 singleParticleNoise(real T, real L, real psi) {
       abs(variance.y - 2 * T * selfMobility) > tol or
       abs(variance.z - 2 * T * selfMobility) > tol) {
     sys->log<System::ERROR>("[noiseVariance] Incorrect noise correlation for "
-                            "psi = %f; noiseCorr=%.5e %.5e %.5e, kT·M0=%.5e",
+                            "psi = %f; noiseCorr=%.5e %.5e %.5e, kT*M0=%.5e",
                             psi, variance.x, variance.y, variance.z,
                             T * selfMobility);
   }

--- a/test/Hydro/ICM_Compressible/computeStructureFactor.cuh
+++ b/test/Hydro/ICM_Compressible/computeStructureFactor.cuh
@@ -6,7 +6,7 @@
 #include "utils/cufftPrecisionAgnostic.h"
 namespace uammd {
 
-// A functor to compute a fourier correlation, computes a·b^*
+// A functor to compute a fourier correlation, computes a*b^*
 struct Convolution {
   real nomalization;
   Convolution(real normalization) : nomalization(normalization) {}
@@ -30,7 +30,7 @@ public:
                 CUFFT_Real2Complex<real>::value);
   }
 
-  // Computes S(k) = <a_k·b_k^*> given a(r) and b(r)
+  // Computes S(k) = <a_k*b_k^*> given a(r) and b(r)
   template <class RealIterator> auto compute(RealIterator a, RealIterator b) {
     int n = ncells.x * ncells.y * ncells.z;
     int nhat = (ncells.x / 2 + 1) * ncells.y * ncells.z;

--- a/test/MC/ShortRange/MonteCarlo.cu
+++ b/test/MC/ShortRange/MonteCarlo.cu
@@ -60,11 +60,11 @@ int main(int argc, char *argv[]) {
   }
   if (shift)
     sys->log<System::MESSAGE>("[System] LJ Parameters: sigma %e, epsilon %e, "
-                              "cutOff %e·sigma, shift: truncated and shifted",
+                              "cutOff %e*sigma, shift: truncated and shifted",
                               sigma, epsilon, cutOff);
   else
     sys->log<System::MESSAGE>("[System] LJ Parameters: sigma %e, epsilon %e, "
-                              "cutOff %e·sigma, shift: truncated",
+                              "cutOff %e*sigma, shift: truncated",
                               sigma, epsilon, cutOff);
 
   auto pot = make_shared<Potential::LJ>();


### PR DESCRIPTION
I converted some functions to Doxygen stuff but then realized the non-ascii problem was more widespread than I thought. I bulk find-replaced some of it and manually went through the rest- I didn't get everything, but I got most of the stuff under src/. I tested compiling libmobility in debug mode against this using

```
FetchContent_Declare(
  uammd
  GIT_REPOSITORY https://github.com/rykerfish/UAMMD
  GIT_TAG        origin/remove_non_ascii
  EXCLUDE_FROM_ALL
)
```

and it compiled fine, whereas previously it would throw the error about non-ascii symbols when using `-src-in-ptx`. 