### PR TITLE
build: specify openmp for libopenblas

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - libblas
   - pybind11
   - python 3.11.*
+  - libopenblas=*=*openmp*


### PR DESCRIPTION
I was able to reproduce the error I was having the other day where DPStokes would hang with the error "OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option."

It happens when a version of libopenblas with pthreads is installed (which is [possibly](https://conda-forge.org/news/2020/07/17/conda-forge-is-building-openblas-with-both-pthreads-and-openmp-on-linux/) the default). DPStokes can work with pthreads when using OMP_NUM_THREADS=1 but initialization is quite slow. Instead, I was able to fix it by specifying libopenblas using openmp. 

I think this is the correct syntax to only specify an openmp version IF libopenblas is installed, so hopefully other blas implementations could still be installed depending on what conda decides. Feel free to modify if I got it incorrect since I was a bit unsure.